### PR TITLE
feat: add arm64 (aarch64) ISO build support

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -20,8 +20,20 @@ on:
 
 jobs:
   build-and-publish:
-    name: Build Dakota Live ISO
-    runs-on: ubuntu-24.04
+    name: Build Dakota Live ISO (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            iso_suffix: ""
+            latest_base: dakota-live-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            iso_suffix: "-aarch64"
+            latest_base: dakota-live-aarch64-latest
     permissions:
       contents: read
       packages: read
@@ -69,7 +81,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y%m%d)
           SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "dated=dakota-live-${DATE}-${SHA}.iso" >> "$GITHUB_OUTPUT"
+          echo "dated=dakota-live${{ matrix.iso_suffix }}-${DATE}-${SHA}.iso" >> "$GITHUB_OUTPUT"
           echo "path=output/dakota-live.iso" >> "$GITHUB_OUTPUT"
 
       - name: Generate SHA256 checksum
@@ -78,12 +90,12 @@ jobs:
           ISO="${{ steps.iso.outputs.path }}"
           DATED="${{ steps.iso.outputs.dated }}"
           CHECKSUM_PATH="output/${DATED}-CHECKSUM"
-          LATEST_CHECKSUM_PATH="output/dakota-live-latest.iso-CHECKSUM"
+          LATEST_CHECKSUM_PATH="output/${{ matrix.latest_base }}.iso-CHECKSUM"
           # Full sha256sum format (hash + filename) so users can run: sha256sum -c
           # Two manifests: one with the dated filename, one with the "latest" alias.
           # They share the same hash but different recorded filenames so both work.
           sha256sum "$ISO" | sed "s|output/dakota-live.iso|${DATED}|" | tee "$CHECKSUM_PATH"
-          sha256sum "$ISO" | sed "s|output/dakota-live.iso|dakota-live-latest.iso|" > "$LATEST_CHECKSUM_PATH"
+          sha256sum "$ISO" | sed "s|output/dakota-live.iso|${{ matrix.latest_base }}.iso|" > "$LATEST_CHECKSUM_PATH"
           echo "path=${CHECKSUM_PATH}" >> "$GITHUB_OUTPUT"
           echo "name=${DATED}-CHECKSUM" >> "$GITHUB_OUTPUT"
           echo "latest_path=${LATEST_CHECKSUM_PATH}" >> "$GITHUB_OUTPUT"
@@ -101,66 +113,105 @@ jobs:
           ISO="${{ steps.iso.outputs.path }}"
           DATED="${{ steps.iso.outputs.dated }}"
           BUCKET="${{ secrets.R2_BUCKET }}"
+          LATEST="${{ matrix.latest_base }}.iso"
 
           echo "==> Uploading as $DATED ..."
           rclone copyto --log-level INFO --checksum --s3-no-check-bucket \
             "$ISO" "R2:testing/${DATED}"
 
-          echo "==> Updating dakota-live-latest.iso ..."
+          echo "==> Updating ${LATEST} ..."
           rclone copyto --log-level INFO --s3-no-check-bucket \
-            "$ISO" "R2:testing/dakota-live-latest.iso"
+            "$ISO" "R2:testing/${LATEST}"
 
           echo "==> Uploading checksum as ${{ steps.checksum.outputs.name }} ..."
           rclone copyto --log-level INFO --s3-no-check-bucket \
             "${{ steps.checksum.outputs.path }}" \
             "R2:testing/${{ steps.checksum.outputs.name }}"
 
-          echo "==> Updating dakota-live-latest.iso-CHECKSUM ..."
+          echo "==> Updating ${LATEST}-CHECKSUM ..."
           rclone copyto --log-level INFO --s3-no-check-bucket \
             "${{ steps.checksum.outputs.latest_path }}" \
-            "R2:testing/dakota-live-latest.iso-CHECKSUM"
+            "R2:testing/${LATEST}-CHECKSUM"
 
           echo "==> Done. Public URLs:"
-          echo "    https://projectbluefin.dev/dakota-live-latest.iso"
-          echo "    https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM"
+          echo "    https://projectbluefin.dev/${LATEST}"
+          echo "    https://projectbluefin.dev/${LATEST}-CHECKSUM"
 
       - name: Boot verification (UEFI + serial)
         timeout-minutes: 10
         run: |
-          sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick -qq
-
+          ARCH="${{ matrix.arch }}"
           ISO="${{ steps.iso.outputs.path }}"
-          echo "==> Booting $ISO ..."
 
-          OVMF_CODE=""
-          for f in /usr/share/OVMF/OVMF_CODE_4M.fd \
-                   /usr/share/OVMF/OVMF_CODE.fd \
-                   /usr/share/edk2/ovmf/OVMF_CODE.fd; do
-            [ -f "$f" ] && OVMF_CODE="$f" && break
-          done
-          OVMF_VARS=""
-          for f in /usr/share/OVMF/OVMF_VARS_4M.fd \
-                   /usr/share/OVMF/OVMF_VARS.fd \
-                   /usr/share/edk2/ovmf/OVMF_VARS.fd; do
-            if [ -f "$f" ]; then
-              cp "$f" /tmp/OVMF_VARS.fd
-              OVMF_VARS="/tmp/OVMF_VARS.fd"
-              break
-            fi
-          done
-
-          PFLASH=()
-          if [ -n "$OVMF_CODE" ] && [ -n "$OVMF_VARS" ]; then
-            echo "==> UEFI firmware: $OVMF_CODE"
-            PFLASH+=(-drive "if=pflash,format=raw,readonly=on,file=$OVMF_CODE")
-            PFLASH+=(-drive "if=pflash,format=raw,file=$OVMF_VARS")
+          if [[ "$ARCH" == "aarch64" ]]; then
+            sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 socat imagemagick -qq
+          else
+            sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick -qq
           fi
 
-          sudo qemu-system-x86_64 \
-            -machine type=q35,accel=kvm \
+          echo "==> Booting $ISO ($ARCH)..."
+
+          # Locate UEFI firmware (paths vary by Ubuntu release and arch)
+          EFI_CODE=""; EFI_VARS=""
+          if [[ "$ARCH" == "aarch64" ]]; then
+            for f in /usr/share/AAVMF/AAVMF_CODE.fd \
+                     /usr/share/qemu-efi-aarch64/QEMU_EFI.fd; do
+              [ -f "$f" ] && EFI_CODE="$f" && break
+            done
+            for f in /usr/share/AAVMF/AAVMF_VARS.fd \
+                     /usr/share/qemu-efi-aarch64/QEMU_VARS.fd; do
+              if [ -f "$f" ]; then
+                cp "$f" /tmp/EFI_VARS.fd
+                EFI_VARS="/tmp/EFI_VARS.fd"
+                break
+              fi
+            done
+          else
+            for f in /usr/share/OVMF/OVMF_CODE_4M.fd \
+                     /usr/share/OVMF/OVMF_CODE.fd \
+                     /usr/share/edk2/ovmf/OVMF_CODE.fd; do
+              [ -f "$f" ] && EFI_CODE="$f" && break
+            done
+            for f in /usr/share/OVMF/OVMF_VARS_4M.fd \
+                     /usr/share/OVMF/OVMF_VARS.fd \
+                     /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+              if [ -f "$f" ]; then
+                cp "$f" /tmp/EFI_VARS.fd
+                EFI_VARS="/tmp/EFI_VARS.fd"
+                break
+              fi
+            done
+          fi
+
+          PFLASH=()
+          if [ -n "$EFI_CODE" ] && [ -n "$EFI_VARS" ]; then
+            echo "==> UEFI firmware: $EFI_CODE"
+            PFLASH+=(-drive "if=pflash,format=raw,readonly=on,file=$EFI_CODE")
+            PFLASH+=(-drive "if=pflash,format=raw,file=$EFI_VARS")
+          fi
+
+          # aarch64: virt machine + virtio-scsi CD-ROM (no IDE/ATAPI); serial → ttyAMA0 (PL011)
+          # amd64:   q35 machine + ATAPI CD-ROM;                        serial → ttyS0 (16550)
+          # Both attach the ISO as optical media so UEFI firmware reads the El Torito EFI entry.
+          if [[ "$ARCH" == "aarch64" ]]; then
+            QEMU_BIN="qemu-system-aarch64"
+            MACHINE="virt,accel=kvm"
+            ISO_ARGS=(
+              -drive "if=none,id=live-disk,file=$ISO,media=cdrom,format=raw,readonly=on"
+              -device virtio-scsi-pci,id=scsi
+              -device scsi-cd,drive=live-disk
+            )
+          else
+            QEMU_BIN="qemu-system-x86_64"
+            MACHINE="type=q35,accel=kvm"
+            ISO_ARGS=(-cdrom "$ISO" -boot d)
+          fi
+
+          sudo "$QEMU_BIN" \
+            -machine "$MACHINE" \
             -cpu host -m 4G -smp 2 \
-            -cdrom "$ISO" -boot d \
             "${PFLASH[@]}" \
+            "${ISO_ARGS[@]}" \
             -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
             -serial file:/tmp/serial.log \
             -display none \
@@ -219,6 +270,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: boot-screenshot
+          name: boot-screenshot-${{ matrix.arch }}
           path: screenshot.png
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Dakota Live ISO
 
-[![Build and Publish](https://github.com/tuna-os/dakota-iso/actions/workflows/build-iso.yml/badge.svg)](https://github.com/tuna-os/dakota-iso/actions/workflows/build-iso.yml)
+[![Build and Publish](https://github.com/projectbluefin/dakota-iso/actions/workflows/build-iso.yml/badge.svg)](https://github.com/projectbluefin/dakota-iso/actions/workflows/build-iso.yml)
 
-**[⬇ Download Latest ISO](https://download.tunaos.org/dakota/dakota-live-latest.iso)**
+| Architecture | Download |
+|---|---|
+| x86_64 (amd64) | **[⬇ dakota-live-latest.iso](https://projectbluefin.dev/dakota-live-latest.iso)** · [checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM) |
+| aarch64 (arm64) | **[⬇ dakota-live-aarch64-latest.iso](https://projectbluefin.dev/dakota-live-aarch64-latest.iso)** · [checksum](https://projectbluefin.dev/dakota-live-aarch64-latest.iso-CHECKSUM) |
 
 Builds a bootable UEFI live ISO from the [Dakota](https://github.com/projectbluefin/dakota) image — a GNOME OS-based workstation using composefs and systemd-boot. The live environment boots straight to GDM with a full GNOME session and launches the Dakota installer automatically.
 
@@ -26,8 +29,10 @@ At boot, `dmsquash-live` mounts the squashfs and creates an overlayfs so the liv
 |---|---|
 | `podman` | Rootless works; needs `--cap-add sys_admin` for the live env build |
 | `just` | Task runner — `cargo install just` or distro package |
-| KVM + `qemu-system-x86_64` | For local boot testing only |
-| OVMF firmware | `edk2-ovmf` (Fedora/RHEL) or `ovmf` (Debian/Ubuntu) |
+| KVM + `qemu-system-x86_64` | For local boot testing on amd64 only |
+| KVM + `qemu-system-aarch64` | For local boot testing on aarch64 only |
+| OVMF firmware | `edk2-ovmf` (Fedora/RHEL) or `ovmf` (Debian/Ubuntu) — amd64 |
+| AAVMF firmware | `edk2-aarch64` (Fedora/RHEL) or `qemu-efi-aarch64` (Debian/Ubuntu) — aarch64 |
 
 **Disk space:** The build needs ~22 GB free:
 - ~12 GB for the rootfs tarball (Flatpak-heavy)
@@ -40,7 +45,7 @@ By default, output goes to `./output/`. If `/tmp` is a small tmpfs on your machi
 
 ```bash
 # Clone the repo
-git clone https://github.com/tuna-os/dakota-iso
+git clone https://github.com/projectbluefin/dakota-iso
 cd dakota-iso
 
 # Full build — live env container + ISO assembly

--- a/dakota/src/build-iso.sh
+++ b/dakota/src/build-iso.sh
@@ -8,7 +8,7 @@
 #
 # Boot architecture (no GRUB2, no shim):
 #   El Torito EFI entry → EFI/efi.img (FAT ESP image containing):
-#     EFI/BOOT/BOOTX64.EFI     systemd-bootx64.efi from Dakota
+#     EFI/BOOT/BOOTX64.EFI or BOOTAA64.EFI  systemd-boot EFI binary from Dakota (arch-detected)
 #     loader/loader.conf        systemd-boot configuration
 #     loader/entries/dakota-live.conf   boot entry (kernel + initrd + cmdline)
 #     images/pxeboot/vmlinuz    Dakota kernel
@@ -49,13 +49,30 @@ echo ">>> Kernel: ${kernel}"
 
 VMLINUZ="${BOOT_DIR}/usr/lib/modules/${kernel}/vmlinuz"
 INITRD="${BOOT_DIR}/usr/lib/modules/${kernel}/initramfs.img"
-BOOTX64="${BOOT_DIR}/usr/lib/systemd/boot/efi/systemd-bootx64.efi"
 
-for f in "${VMLINUZ}" "${INITRD}" "${BOOTX64}"; do
+# Detect EFI binary: arm64 ships systemd-bootaa64.efi → BOOTAA64.EFI
+#                   amd64 ships systemd-bootx64.efi  → BOOTX64.EFI
+BOOT_EFI_SRC=""
+BOOT_EFI_DEST=""
+for _candidate in \
+    "systemd-bootaa64.efi:EFI/BOOT/BOOTAA64.EFI" \
+    "systemd-bootx64.efi:EFI/BOOT/BOOTX64.EFI"; do
+    _src="${BOOT_DIR}/usr/lib/systemd/boot/efi/${_candidate%%:*}"
+    _dest="${_candidate##*:}"
+    if [[ -f "${_src}" ]]; then
+        BOOT_EFI_SRC="${_src}"
+        BOOT_EFI_DEST="${_dest}"
+        break
+    fi
+done
+[[ -n "${BOOT_EFI_SRC}" ]] || { echo "ERROR: no systemd-boot EFI binary found in boot-files tar"; exit 1; }
+
+for f in "${VMLINUZ}" "${INITRD}" "${BOOT_EFI_SRC}"; do
     [[ -f "${f}" ]] || { echo "ERROR: missing ${f}"; exit 1; }
 done
 echo ">>> Kernel:   $(du -sh "${VMLINUZ}"  | cut -f1)"
 echo ">>> Initramfs: $(du -sh "${INITRD}"   | cut -f1)"
+echo ">>> EFI:      ${BOOT_EFI_SRC} → ${BOOT_EFI_DEST}"
 
 # ── Assemble the ESP staging directory ──────────────────────────────────────
 # systemd-boot reads loader entries and kernel/initramfs exclusively from the
@@ -65,7 +82,7 @@ mkdir -p \
     "${ESP_STAGING}/loader/entries" \
     "${ESP_STAGING}/images/pxeboot"
 
-cp "${BOOTX64}" "${ESP_STAGING}/EFI/BOOT/BOOTX64.EFI"
+cp "${BOOT_EFI_SRC}" "${ESP_STAGING}/${BOOT_EFI_DEST}"
 cp "${VMLINUZ}" "${ESP_STAGING}/images/pxeboot/vmlinuz"
 cp "${INITRD}"  "${ESP_STAGING}/images/pxeboot/initrd.img"
 
@@ -79,12 +96,14 @@ EOF
 #   rd.live.image               enable dmsquash-live mode
 #   rd.live.overlay.overlayfs=1 use overlayfs (not device mapper) for the rw layer
 #   enforcing=0                 disable SELinux enforcement (GNOME OS ships it)
-#   console=ttyS0,115200n8      serial output — validation target
+#   console=ttyAMA0,115200n8    serial output on arm64 (PL011/QEMU virt) — validation target
+#   console=ttyS0,115200n8      serial output on amd64 (16550/QEMU q35) — validation target
+#   Both consoles listed: Linux silently ignores the one that doesn't exist on the running arch.
 cat > "${ESP_STAGING}/loader/entries/dakota-live.conf" << EOF
 title   Dakota Live
 linux   /images/pxeboot/vmlinuz
 initrd  /images/pxeboot/initrd.img
-options root=live:CDLABEL=${LABEL} rd.live.image rd.live.overlay.overlayfs=1 enforcing=0 quiet console=ttyS0,115200n8
+options root=live:CDLABEL=${LABEL} rd.live.image rd.live.overlay.overlayfs=1 enforcing=0 quiet console=ttyAMA0,115200n8 console=ttyS0,115200n8
 EOF
 
 # ── Create the FAT ESP image ──────────────────────────────────────────────────
@@ -111,7 +130,7 @@ mmd -i "${ESP_IMG}" \
     ::/images \
     ::/images/pxeboot
 
-mcopy -i "${ESP_IMG}" "${ESP_STAGING}/EFI/BOOT/BOOTX64.EFI"            ::/EFI/BOOT/BOOTX64.EFI
+mcopy -i "${ESP_IMG}" "${ESP_STAGING}/${BOOT_EFI_DEST}"            ::/"${BOOT_EFI_DEST}"
 mcopy -i "${ESP_IMG}" "${ESP_STAGING}/loader/loader.conf"               ::/loader/loader.conf
 mcopy -i "${ESP_IMG}" "${ESP_STAGING}/loader/entries/dakota-live.conf"  ::/loader/entries/dakota-live.conf
 mcopy -i "${ESP_IMG}" "${ESP_STAGING}/images/pxeboot/vmlinuz"           ::/images/pxeboot/vmlinuz


### PR DESCRIPTION
## Summary

Adds parallel arm64 ISO builds to the CI pipeline alongside the existing amd64 build.

## Changes

**`.github/workflows/build-iso.yml`**
- `strategy.matrix` with two legs: amd64 (`ubuntu-24.04`) and aarch64 (`ubuntu-24.04-arm`)
- `fail-fast: false` — one arch failure doesn't cancel the other
- Boot test: `qemu-system-aarch64` + AAVMF + virtio-scsi CD-ROM for arm64 (mirrors how the justfile boots the ISO locally)
- Artifact and screenshot names include arch to avoid collision

**`dakota/src/build-iso.sh`**
- Auto-detects which systemd-boot EFI binary is present (`systemd-bootaa64.efi` or `systemd-bootx64.efi`) and sets the correct ESP destination (`BOOTAA64.EFI` / `BOOTX64.EFI`)
- Kernel cmdline gains `console=ttyAMA0,115200n8` before `ttyS0` — Linux ignores the console that doesn't exist on the running arch

**`README.md`**
- Replace single download button with arch table (amd64 + aarch64, each with checksum link)
- Add AAVMF row to requirements table
- Fix stale clone URL (`tuna-os` → `projectbluefin`)

## Naming convention

| | amd64 | aarch64 |
|---|---|---|
| Dated | `dakota-live-YYYYMMDD-\<sha\>.iso` | `dakota-live-aarch64-YYYYMMDD-\<sha\>.iso` |
| Latest | `dakota-live-latest.iso` | `dakota-live-aarch64-latest.iso` |

amd64 names are **unchanged** (backward-compatible).

## ⚠️ Prerequisite

`ghcr.io/projectbluefin/dakota:latest` is currently amd64-only. The arm64 CI leg will fail at image pull until the base image gains an arm64 manifest. The workflow changes can merge independently — the arm64 job will fail clearly rather than silently.