### PR TITLE
fix: arm64 CI follow-ups after PR #6

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -22,6 +22,7 @@ jobs:
   build-and-publish:
     name: Build Dakota Live ISO (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}
+    continue-on-error: ${{ matrix.continue_on_error == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -30,10 +31,14 @@ jobs:
             runner: ubuntu-24.04
             iso_suffix: ""
             latest_base: dakota-live-latest
+            continue_on_error: false
           - arch: aarch64
             runner: ubuntu-24.04-arm
             iso_suffix: "-aarch64"
             latest_base: dakota-live-aarch64-latest
+            # Base image is amd64-only until projectbluefin/dakota publishes a multi-arch manifest.
+            # Allow this leg to fail without blocking the overall workflow or the amd64 upload.
+            continue_on_error: true
     permissions:
       contents: read
       packages: read
@@ -259,7 +264,7 @@ jobs:
 
       - name: Upload SHA256 checksum as artifact
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.checksum.outputs.path != ''
         with:
           name: checksum-${{ steps.iso.outputs.dated }}
           path: ${{ steps.checksum.outputs.path }}

--- a/dakota/src/build-iso.sh
+++ b/dakota/src/build-iso.sh
@@ -96,14 +96,15 @@ EOF
 #   rd.live.image               enable dmsquash-live mode
 #   rd.live.overlay.overlayfs=1 use overlayfs (not device mapper) for the rw layer
 #   enforcing=0                 disable SELinux enforcement (GNOME OS ships it)
-#   console=ttyAMA0,115200n8    serial output on arm64 (PL011/QEMU virt) — validation target
 #   console=ttyS0,115200n8      serial output on amd64 (16550/QEMU q35) — validation target
+#   console=ttyAMA0,115200n8    serial output on arm64 (PL011/QEMU virt) — validation target; listed
+#                                last so it wins /dev/console on hardware where both UARTs exist
 #   Both consoles listed: Linux silently ignores the one that doesn't exist on the running arch.
 cat > "${ESP_STAGING}/loader/entries/dakota-live.conf" << EOF
 title   Dakota Live
 linux   /images/pxeboot/vmlinuz
 initrd  /images/pxeboot/initrd.img
-options root=live:CDLABEL=${LABEL} rd.live.image rd.live.overlay.overlayfs=1 enforcing=0 quiet console=ttyAMA0,115200n8 console=ttyS0,115200n8
+options root=live:CDLABEL=${LABEL} rd.live.image rd.live.overlay.overlayfs=1 enforcing=0 quiet console=ttyS0,115200n8 console=ttyAMA0,115200n8
 EOF
 
 # ── Create the FAT ESP image ──────────────────────────────────────────────────


### PR DESCRIPTION
Three fixes for the aarch64 matrix leg added in PR #6:

1. console= order: ttyS0 first, ttyAMA0 last so arm64 hardware with both PL011 and 16550 UARTs correctly assigns /dev/console to ttyAMA0 (last valid console= wins per kernel docs). No change on QEMU where only one device exists per arch. (Gemini review finding.)

2. continue-on-error: ghcr.io/projectbluefin/dakota:latest is amd64-only. The aarch64 job fails with Exec format error when it tries to RUN commands inside the amd64 container on an arm64 host. Allow the leg to fail gracefully so the overall workflow and amd64 upload are not blocked. Remove continue_on_error once the base image is multi-arch.

3. Checksum artifact upload: the step used if: always() causing 'Input required and not supplied: path' when the build failed and steps.checksum.outputs.path was empty. Guard with steps.checksum.outputs.path != '' instead.