### PR TITLE
fix: add SYS_ADMIN cap to skopeo VFS import container

### DIFF
--- a/justfile
+++ b/justfile
@@ -136,6 +136,7 @@ iso-sd-boot target:
         podman run --rm \
             --user 0 \
             --security-opt label=disable \
+            --cap-add SYS_ADMIN \
             -v \"\${PAYLOAD_OCI}:/payload.oci.tar:ro\" \
             -v \"\${SQUASHFS_STORAGE}:/vfs-storage\" \
             -v \"\${STORAGE_CONF}:/tmp/st.conf:ro\" \


### PR DESCRIPTION
podman drops CAP_SYS_ADMIN by default when starting a container. The skopeo import step (added in eddbf7a) needs to remount / with MS_PRIVATE|MS_REC to isolate the container's mount namespace — this requires CAP_SYS_ADMIN. Without it podman fails immediately with:

  remount /, flags: 0x44000: permission denied

The outer 'container' recipe already passes --cap-add sys_admin for the installer image build; this aligns the inner podman run to match.