### PR TITLE
fix: remove premature aarch64 CI leg and revert README

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -20,25 +20,8 @@ on:
 
 jobs:
   build-and-publish:
-    name: Build Dakota Live ISO (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    continue-on-error: ${{ matrix.continue_on_error == true }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-24.04
-            iso_suffix: ""
-            latest_base: dakota-live-latest
-            continue_on_error: false
-          - arch: aarch64
-            runner: ubuntu-24.04-arm
-            iso_suffix: "-aarch64"
-            latest_base: dakota-live-aarch64-latest
-            # Base image is amd64-only until projectbluefin/dakota publishes a multi-arch manifest.
-            # Allow this leg to fail without blocking the overall workflow or the amd64 upload.
-            continue_on_error: true
+    name: Build Dakota Live ISO
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: read
@@ -86,7 +69,7 @@ jobs:
         run: |
           DATE=$(date -u +%Y%m%d)
           SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "dated=dakota-live${{ matrix.iso_suffix }}-${DATE}-${SHA}.iso" >> "$GITHUB_OUTPUT"
+          echo "dated=dakota-live-${DATE}-${SHA}.iso" >> "$GITHUB_OUTPUT"
           echo "path=output/dakota-live.iso" >> "$GITHUB_OUTPUT"
 
       - name: Generate SHA256 checksum
@@ -95,12 +78,12 @@ jobs:
           ISO="${{ steps.iso.outputs.path }}"
           DATED="${{ steps.iso.outputs.dated }}"
           CHECKSUM_PATH="output/${DATED}-CHECKSUM"
-          LATEST_CHECKSUM_PATH="output/${{ matrix.latest_base }}.iso-CHECKSUM"
+          LATEST_CHECKSUM_PATH="output/dakota-live-latest.iso-CHECKSUM"
           # Full sha256sum format (hash + filename) so users can run: sha256sum -c
           # Two manifests: one with the dated filename, one with the "latest" alias.
           # They share the same hash but different recorded filenames so both work.
           sha256sum "$ISO" | sed "s|output/dakota-live.iso|${DATED}|" | tee "$CHECKSUM_PATH"
-          sha256sum "$ISO" | sed "s|output/dakota-live.iso|${{ matrix.latest_base }}.iso|" > "$LATEST_CHECKSUM_PATH"
+          sha256sum "$ISO" | sed "s|output/dakota-live.iso|dakota-live-latest.iso|" > "$LATEST_CHECKSUM_PATH"
           echo "path=${CHECKSUM_PATH}" >> "$GITHUB_OUTPUT"
           echo "name=${DATED}-CHECKSUM" >> "$GITHUB_OUTPUT"
           echo "latest_path=${LATEST_CHECKSUM_PATH}" >> "$GITHUB_OUTPUT"
@@ -118,7 +101,7 @@ jobs:
           ISO="${{ steps.iso.outputs.path }}"
           DATED="${{ steps.iso.outputs.dated }}"
           BUCKET="${{ secrets.R2_BUCKET }}"
-          LATEST="${{ matrix.latest_base }}.iso"
+          LATEST="dakota-live-latest.iso"
 
           echo "==> Uploading as $DATED ..."
           rclone copyto --log-level INFO --checksum --s3-no-check-bucket \
@@ -145,48 +128,28 @@ jobs:
       - name: Boot verification (UEFI + serial)
         timeout-minutes: 10
         run: |
-          ARCH="${{ matrix.arch }}"
           ISO="${{ steps.iso.outputs.path }}"
 
-          if [[ "$ARCH" == "aarch64" ]]; then
-            sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 socat imagemagick -qq
-          else
-            sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick -qq
-          fi
+          sudo apt-get install -y qemu-system-x86 ovmf socat imagemagick -qq
 
-          echo "==> Booting $ISO ($ARCH)..."
+          echo "==> Booting $ISO ..."
 
-          # Locate UEFI firmware (paths vary by Ubuntu release and arch)
+          # Locate UEFI firmware (paths vary by Ubuntu release)
           EFI_CODE=""; EFI_VARS=""
-          if [[ "$ARCH" == "aarch64" ]]; then
-            for f in /usr/share/AAVMF/AAVMF_CODE.fd \
-                     /usr/share/qemu-efi-aarch64/QEMU_EFI.fd; do
-              [ -f "$f" ] && EFI_CODE="$f" && break
-            done
-            for f in /usr/share/AAVMF/AAVMF_VARS.fd \
-                     /usr/share/qemu-efi-aarch64/QEMU_VARS.fd; do
-              if [ -f "$f" ]; then
-                cp "$f" /tmp/EFI_VARS.fd
-                EFI_VARS="/tmp/EFI_VARS.fd"
-                break
-              fi
-            done
-          else
-            for f in /usr/share/OVMF/OVMF_CODE_4M.fd \
-                     /usr/share/OVMF/OVMF_CODE.fd \
-                     /usr/share/edk2/ovmf/OVMF_CODE.fd; do
-              [ -f "$f" ] && EFI_CODE="$f" && break
-            done
-            for f in /usr/share/OVMF/OVMF_VARS_4M.fd \
-                     /usr/share/OVMF/OVMF_VARS.fd \
-                     /usr/share/edk2/ovmf/OVMF_VARS.fd; do
-              if [ -f "$f" ]; then
-                cp "$f" /tmp/EFI_VARS.fd
-                EFI_VARS="/tmp/EFI_VARS.fd"
-                break
-              fi
-            done
-          fi
+          for f in /usr/share/OVMF/OVMF_CODE_4M.fd \
+                   /usr/share/OVMF/OVMF_CODE.fd \
+                   /usr/share/edk2/ovmf/OVMF_CODE.fd; do
+            [ -f "$f" ] && EFI_CODE="$f" && break
+          done
+          for f in /usr/share/OVMF/OVMF_VARS_4M.fd \
+                   /usr/share/OVMF/OVMF_VARS.fd \
+                   /usr/share/edk2/ovmf/OVMF_VARS.fd; do
+            if [ -f "$f" ]; then
+              cp "$f" /tmp/EFI_VARS.fd
+              EFI_VARS="/tmp/EFI_VARS.fd"
+              break
+            fi
+          done
 
           PFLASH=()
           if [ -n "$EFI_CODE" ] && [ -n "$EFI_VARS" ]; then
@@ -195,28 +158,11 @@ jobs:
             PFLASH+=(-drive "if=pflash,format=raw,file=$EFI_VARS")
           fi
 
-          # aarch64: virt machine + virtio-scsi CD-ROM (no IDE/ATAPI); serial → ttyAMA0 (PL011)
-          # amd64:   q35 machine + ATAPI CD-ROM;                        serial → ttyS0 (16550)
-          # Both attach the ISO as optical media so UEFI firmware reads the El Torito EFI entry.
-          if [[ "$ARCH" == "aarch64" ]]; then
-            QEMU_BIN="qemu-system-aarch64"
-            MACHINE="virt,accel=kvm:tcg"
-            ISO_ARGS=(
-              -drive "if=none,id=live-disk,file=$ISO,media=cdrom,format=raw,readonly=on"
-              -device virtio-scsi-pci,id=scsi
-              -device scsi-cd,drive=live-disk
-            )
-          else
-            QEMU_BIN="qemu-system-x86_64"
-            MACHINE="type=q35,accel=kvm"
-            ISO_ARGS=(-cdrom "$ISO" -boot d)
-          fi
-
-          sudo "$QEMU_BIN" \
-            -machine "$MACHINE" \
+          sudo qemu-system-x86_64 \
+            -machine type=q35,accel=kvm \
             -cpu host -m 4G -smp 2 \
             "${PFLASH[@]}" \
-            "${ISO_ARGS[@]}" \
+            -cdrom "$ISO" -boot d \
             -monitor unix:/tmp/qemu-monitor.sock,server,nowait \
             -serial file:/tmp/serial.log \
             -display none \
@@ -275,6 +221,6 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: boot-screenshot-${{ matrix.arch }}
+          name: boot-screenshot-amd64
           path: screenshot.png
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 [![Build and Publish](https://github.com/projectbluefin/dakota-iso/actions/workflows/build-iso.yml/badge.svg)](https://github.com/projectbluefin/dakota-iso/actions/workflows/build-iso.yml)
 
-| Architecture | Download |
-|---|---|
-| x86_64 (amd64) | **[⬇ dakota-live-latest.iso](https://projectbluefin.dev/dakota-live-latest.iso)** · [checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM) |
-| aarch64 (arm64) | **[⬇ dakota-live-aarch64-latest.iso](https://projectbluefin.dev/dakota-live-aarch64-latest.iso)** · [checksum](https://projectbluefin.dev/dakota-live-aarch64-latest.iso-CHECKSUM) |
+**[⬇ Download Latest ISO (amd64)](https://projectbluefin.dev/dakota-live-latest.iso)** · [checksum](https://projectbluefin.dev/dakota-live-latest.iso-CHECKSUM)
 
 Builds a bootable UEFI live ISO from the [Dakota](https://github.com/projectbluefin/dakota) image — a GNOME OS-based workstation using composefs and systemd-boot. The live environment boots straight to GDM with a full GNOME session and launches the Dakota installer automatically.
 
@@ -30,9 +27,7 @@ At boot, `dmsquash-live` mounts the squashfs and creates an overlayfs so the liv
 | `podman` | Rootless works; needs `--cap-add sys_admin` for the live env build |
 | `just` | Task runner — `cargo install just` or distro package |
 | KVM + `qemu-system-x86_64` | For local boot testing on amd64 only |
-| KVM + `qemu-system-aarch64` | For local boot testing on aarch64 only |
 | OVMF firmware | `edk2-ovmf` (Fedora/RHEL) or `ovmf` (Debian/Ubuntu) — amd64 |
-| AAVMF firmware | `edk2-aarch64` (Fedora/RHEL) or `qemu-efi-aarch64` (Debian/Ubuntu) — aarch64 |
 
 **Disk space:** The build needs ~22 GB free:
 - ~12 GB for the rootfs tarball (Flatpak-heavy)


### PR DESCRIPTION
The base image ghcr.io/projectbluefin/dakota:latest is amd64-only. The aarch64 matrix entry permanently fails with 'Exec format error' and was masked by continue-on-error, normalizing failure.

Remove the matrix strategy and restore the workflow to a single amd64 job. Remove aarch64 download link and AAVMF/qemu-system-aarch64 rows from README — these artifacts don't exist yet.

The EFI auto-detect and dual-console changes in build-iso.sh are intentionally left in place; they are inert on amd64 and will be needed when arm64 support is re-added.