### PR TITLE
fix: use --privileged for skopeo VFS import container

### DIFF
--- a/justfile
+++ b/justfile
@@ -134,9 +134,7 @@ iso-sd-boot target:
         # carries the same containers/storage version as the live ISO and writes the
         # JSON-based format it expects.
         podman run --rm \
-            --user 0 \
-            --security-opt label=disable \
-            --cap-add SYS_ADMIN \
+            --privileged \
             -v \"\${PAYLOAD_OCI}:/payload.oci.tar:ro\" \
             -v \"\${SQUASHFS_STORAGE}:/vfs-storage\" \
             -v \"\${STORAGE_CONF}:/tmp/st.conf:ro\" \


### PR DESCRIPTION
--cap-add SYS_ADMIN alone is insufficient — podman run uses the default seccomp profile which blocks mount(MS_PRIVATE|MS_REC, 0x44000), causing:

  ApplyLayer: remount /, flags: 0x44000: permission denied

--privileged grants all capabilities AND disables seccomp, allowing containers/storage's ApplyLayer helper to set up a private mount namespace. This matches every other podman run in this justfile (iso-in-container recipe, lines 241/254) which all use --privileged.

podman build uses unconfined seccomp by default (so --cap-add sys_admin suffices there), but podman run does not — hence the inconsistency.

Replaces the partial fix in PR #8 (645e359).