### PR TITLE
fix: write DAKOTA_LIVE_READY directly to /dev/ttyS0 in live-ready.service

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -230,8 +230,12 @@ jobs:
 
           echo "quit" | sudo socat - UNIX-CONNECT:/tmp/qemu-monitor.sock || true
 
-          # Fail the job if the live environment never reached the ready state
-          sudo grep -q "DAKOTA_LIVE_READY" /tmp/serial.log || \
+          # Fail the job if the live environment never reached the ready state.
+          # Accept either the explicit DAKOTA_LIVE_READY token (written directly to
+          # /dev/ttyS0 by live-ready.service) or the systemd completion message from
+          # the same service, which always appears on the console regardless of TTY
+          # routing.
+          sudo grep -qE "DAKOTA_LIVE_READY|Finished live-ready\.service" /tmp/serial.log || \
             { echo "ERROR: Live environment did not reach ready state"; sudo tail -50 /tmp/serial.log; exit 1; }
 
       - name: Upload ISO as artifact

--- a/dakota/src/configure-live.sh
+++ b/dakota/src/configure-live.sh
@@ -206,11 +206,14 @@ systemctl enable var-tmp.mount
 
 # ── Live-ready marker service ─────────────────────────────────────────────────
 # Prints DAKOTA_LIVE_READY to the serial console after display-manager.service
-# starts.  CI boot verification greps for this token to confirm the desktop
-# environment is up, or falls back to SSH connectivity if the marker is absent.
-# WantedBy=multi-user.target (not display-manager.service) to ensure the
-# service is reliably started via the standard boot sequence; After= ordering
-# still guarantees it runs only after GDM/display-manager has started.
+# starts.  CI boot verification greps for this token in the serial log.
+#
+# StandardOutput=tty + TTYPath=/dev/ttyS0 ensures the echo goes to the serial
+# device directly.  StandardOutput=journal+console routes to /dev/console which
+# is NOT the serial device in headless QEMU (-display none, -serial file:...).
+#
+# WantedBy=multi-user.target (not display-manager.service) ensures reliable
+# enablement; After=display-manager.service provides ordering only.
 cat > /usr/lib/systemd/system/live-ready.service << 'LREOF'
 [Unit]
 Description=Live environment ready marker
@@ -220,7 +223,8 @@ Requires=display-manager.service
 [Service]
 Type=oneshot
 ExecStart=/bin/echo DAKOTA_LIVE_READY
-StandardOutput=journal+console
+StandardOutput=tty
+TTYPath=/dev/ttyS0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem

The build-iso.yml boot verification greps for `DAKOTA_LIVE_READY` in `/tmp/serial.log` but the token never arrives.

The ISO boots fine (GDM starts, `[OK] Finished live-ready.service` appears in the serial log), but the `/bin/echo DAKOTA_LIVE_READY` output from the service doesn't reach serial because `StandardOutput=journal+console` routes to `/dev/console` — which is NOT the QEMU serial device when using `-display none -serial file:...`.

## Fix

- Change `live-ready.service` to use `StandardOutput=tty` + `TTYPath=/dev/ttyS0` so the echo goes directly to the serial device.
- Update the boot verification grep to accept either `DAKOTA_LIVE_READY` OR `Finished live-ready.service` (belt-and-suspenders fallback).

The LUKS E2E tests were unaffected because they have an SSH fallback path in the justfile readiness loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced boot verification process to more reliably detect when the system is ready.
  * Improved system readiness detection to recognize multiple initialization confirmation signals during startup.
  * Optimized system startup logging configuration for better visibility during the boot process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->