### PR TITLE
fix(Containerfile): redeclare BUILD_IMAGE again

### DIFF
--- a/dakota/Containerfile
+++ b/dakota/Containerfile
@@ -84,6 +84,7 @@ RUN --mount=type=bind,source=src,target=/src \
 COPY src/ /tmp/src/
 RUN chmod +x /tmp/src/configure-live.sh && /tmp/src/configure-live.sh
 
+ARG BASE_IMAGE
 # Patch installer configs to reference the actual base image for this variant.
 # For the default (BASE_IMAGE=ghcr.io/projectbluefin/dakota:latest) this is a no-op.
 RUN sed -i "s|ghcr.io/projectbluefin/dakota:latest|${BASE_IMAGE}|g" \


### PR DESCRIPTION
The last line of the Containerfile uses BUILD_IMAGE to update the bootc-installer recipe. Since BUILD_IMAGE isn't redeclared after the final FROM, the image is empty so installs fail. The LUKS e2e test doesn't catch this since it scp's a valid recipe.json before installing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability to ensure proper configuration initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->