### PR TITLE
feat: support Ventoy file-backed ISO boot

### DIFF
--- a/dakota/Containerfile
+++ b/dakota/Containerfile
@@ -36,12 +36,15 @@ RUN apt-get update && \
 # Import Dakota's kernel module tree so dracut targets the correct kernel
 COPY --from=dakota-ref /usr/lib/modules /usr/lib/modules
 
+# Add Dakota-specific initramfs support for Ventoy/file-backed ISO boot.
+COPY src/dracut/95dakota-isofile /usr/lib/dracut/modules.d/95dakota-isofile
+
 RUN set -ex; \
     kernel=$(ls /usr/lib/modules | sort -V | tail -1); \
     echo "Building dmsquash-live initramfs for kernel ${kernel}"; \
     DRACUT_NO_XATTR=1 dracut -v --force --zstd --reproducible --no-hostonly \
-        --add "dmsquash-live" \
-        --add-drivers "squashfs overlay loop iso9660 sr_mod cdrom" \
+        --add "dmsquash-live dakota-isofile" \
+        --add-drivers "squashfs overlay loop iso9660 sr_mod cdrom sd_mod usb-storage xhci-pci exfat vfat fat ntfs3 ext4" \
         /tmp/initramfs.img "${kernel}"; \
     ls -lh /tmp/initramfs.img
 

--- a/dakota/src/build-iso.sh
+++ b/dakota/src/build-iso.sh
@@ -16,6 +16,8 @@
 #   ISO9660 root:
 #     EFI/BOOT/BOOTX64.EFI      EFI fallback path (same binary) for Proxmox OVMF / Ventoy
 #     EFI/efi.img               (also referenced by El Torito)
+#     images/pxeboot/*          kernel/initramfs copies for loopback ISO boot tools
+#     boot/grub/loopback.cfg    metadata for Ventoy/GRUB-style loopback boot
 #     LiveOS/squashfs.img       squashfs of the full Dakota live rootfs
 #
 # Live boot flow:
@@ -147,6 +149,20 @@ mcopy -i "${ESP_IMG}" "${ESP_STAGING}/images/pxeboot/initrd.img"        ::/image
 mkdir -p "${ISO_ROOT}/EFI/BOOT"
 cp "${BOOT_EFI_SRC}" "${ISO_ROOT}/${BOOT_EFI_DEST}"
 echo ">>> EFI fallback: ${BOOT_EFI_DEST} added to ISO root"
+
+# ── ISO-root kernel/initramfs and loopback metadata ──────────────────────────
+# Ventoy and GRUB-style loopback boot tools expect kernel/initramfs paths in the
+# ISO filesystem itself, not only inside the El Torito ESP image.
+mkdir -p "${ISO_ROOT}/images/pxeboot" "${ISO_ROOT}/boot/grub"
+cp "${VMLINUZ}" "${ISO_ROOT}/images/pxeboot/vmlinuz"
+cp "${INITRD}"  "${ISO_ROOT}/images/pxeboot/initrd.img"
+cat > "${ISO_ROOT}/boot/grub/loopback.cfg" << EOF
+menuentry "Dakota Live" {
+    linux /images/pxeboot/vmlinuz root=live:CDLABEL=${LABEL} rd.live.image rd.live.overlay.overlayfs=1 enforcing=0 quiet console=ttyS0,115200n8 console=ttyAMA0,115200n8 rd.dakota.isofile=\${iso_path}
+    initrd /images/pxeboot/initrd.img
+}
+EOF
+echo ">>> Loopback boot metadata added to ISO root"
 
 # ── Place the pre-built squashfs ─────────────────────────────────────────────
 echo ">>> Copying squashfs..."

--- a/dakota/src/dracut/95dakota-isofile/dakota-isofile.sh
+++ b/dakota/src/dracut/95dakota-isofile/dakota-isofile.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Locate a Dakota live ISO file on Ventoy/USB partitions and expose it as
+# /dev/disk/by-label/DAKOTA_LIVE so the standard dmsquash-live CDLABEL path works.
+
+LABEL="DAKOTA_LIVE"
+RUN_DIR="/run/initramfs/dakota-isofile"
+FOUND_MARKER="${RUN_DIR}/found"
+
+[ -e "/dev/disk/by-label/${LABEL}" ] && return 0
+[ -e "${FOUND_MARKER}" ] && return 0
+
+mkdir -p "${RUN_DIR}" /dev/disk/by-label
+
+debug() {
+    echo "dakota-isofile: $*" > /dev/kmsg 2>/dev/null || echo "dakota-isofile: $*"
+}
+
+iso_hint=""
+for arg in $(cat /proc/cmdline); do
+    case "$arg" in
+        rd.dakota.isofile=*|findiso=*|iso-scan/filename=*|rd.live.iso=*)
+            iso_hint="${arg#*=}"
+            ;;
+    esac
+done
+
+try_iso() {
+    iso="$1"
+    [ -f "$iso" ] || return 1
+
+    loopdev=$(losetup --find --show --read-only "$iso" 2>/dev/null) || return 1
+    iso_label=$(blkid -s LABEL -o value "$loopdev" 2>/dev/null || true)
+
+    if [ "$iso_label" = "$LABEL" ]; then
+        ln -sf "$loopdev" "/dev/disk/by-label/${LABEL}"
+        : > "${FOUND_MARKER}"
+        udevadm settle 2>/dev/null || true
+        debug "using ISO file $iso via $loopdev"
+        # Manual symlink creation does not trigger the dmsquash-live udev rule,
+        # so queue the same root setup explicitly. Do not create /dev/root here:
+        # dmsquash-live-root creates it after /run/rootfsbase is ready.
+        /sbin/initqueue --settled --onetime --unique /sbin/dmsquash-live-root "$loopdev"
+        return 0
+    fi
+
+    losetup -d "$loopdev" 2>/dev/null || true
+    return 1
+}
+
+scan_mount() {
+    dev="$1"
+    base=$(basename "$dev")
+    mp="${RUN_DIR}/mnt-${base}"
+    mkdir -p "$mp"
+
+    mount -o ro -t auto "$dev" "$mp" 2>/dev/null || return 1
+
+    if [ -n "$iso_hint" ]; then
+        case "$iso_hint" in
+            /*)
+                try_iso "${mp}${iso_hint}" && return 0
+                ;;
+            *)
+                try_iso "${mp}/${iso_hint}" && return 0
+                ;;
+        esac
+    fi
+
+    # Fast common cases first. Avoid deep recursive searches in initramfs.
+    for iso in \
+        "$mp"/dakota*.iso \
+        "$mp"/Dakota*.iso \
+        "$mp"/*.iso \
+        "$mp"/ISO/*.iso \
+        "$mp"/iso/*.iso \
+        "$mp"/*/dakota*.iso \
+        "$mp"/*/*.iso
+    do
+        [ -e "$iso" ] || continue
+        try_iso "$iso" && return 0
+    done
+
+    umount "$mp" 2>/dev/null || true
+    return 1
+}
+
+# Prefer real partition nodes. Skip whole disks and optical devices here because
+# direct ISO block devices are handled by the normal CDLABEL path above.
+for dev in /dev/disk/by-label/* /dev/disk/by-id/*-part* /dev/sd*[0-9] /dev/vd*[0-9] /dev/nvme*n*p* /dev/mmcblk*p*; do
+    [ -b "$dev" ] || continue
+    [ -e "/dev/disk/by-label/${LABEL}" ] && return 0
+    scan_mount "$dev" && return 0
+done
+
+# Keep dracut's initqueue waiting if neither the normal CDLABEL path nor the
+# Ventoy/file-backed path is ready yet.
+return 1

--- a/dakota/src/dracut/95dakota-isofile/module-setup.sh
+++ b/dakota/src/dracut/95dakota-isofile/module-setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Dracut module: support booting Dakota ISO as a file from Ventoy-style media.
+
+check() {
+    return 0
+}
+
+depends() {
+    echo dmsquash-live
+    return 0
+}
+
+installkernel() {
+    instmods loop iso9660 squashfs overlay
+    instmods usb-storage xhci-pci xhci_hcd ehci-pci ehci_hcd uhci-hcd ohci-hcd
+    instmods sd_mod sr_mod virtio_blk virtio_pci virtio_scsi
+    instmods exfat vfat fat ntfs3 ext4 nls_cp437 nls_iso8859_1 nls_utf8
+}
+
+install() {
+    inst_multiple mount umount blkid losetup find grep sed mkdir ln readlink basename cat sleep udevadm
+    inst_hook initqueue 20 "$moddir/dakota-isofile.sh"
+}


### PR DESCRIPTION
## Summary
- add a Dakota dracut module that finds a Dakota ISO file on Ventoy/USB partitions and loop-attaches it for dmsquash-live
- copy kernel/initramfs to the ISO root and add GRUB loopback metadata for Ventoy-style ISO boot tools
- keep direct UEFI CD/USB boot path working

## Local validation
- built debug Dakota ISO locally
- direct UEFI CD-ROM QEMU boot: PASS (`DAKOTA_LIVE_READY`)
- Ventoy 1.1.12 UEFI USB QEMU boot with Dakota ISO as a file on exFAT: PASS (`DAKOTA_LIVE_READY`)

## Notes
This does not add legacy BIOS support; it fixes Ventoy/file-backed ISO boot for UEFI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ISO-file-backed booting. Dakota can now boot directly from ISO files stored on removable media (e.g., Ventoy-backed USB drives). The system automatically detects and initializes the live environment from detected ISO files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->