### PR TITLE
fix(installer): use continuous for stable channel

### DIFF
--- a/.github/workflows/test-luks-install.yml
+++ b/.github/workflows/test-luks-install.yml
@@ -104,7 +104,7 @@ jobs:
         id: luks_test
         run: |
           START=$(date +%s)
-          just luks-test-qemu dakota
+          sudo $(command -v just) luks-test-qemu dakota
           echo "duration=$(( $(date +%s) - START ))" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 

--- a/dakota/src/install-flatpaks.sh
+++ b/dakota/src/install-flatpaks.sh
@@ -38,11 +38,8 @@ flatpak remote-add --system --if-not-exists flathub \
 # INSTALLER_CHANNEL controls which release tag to pull from:
 #   stable (default) → continuous   (latest stable build from main/prod)
 #   dev              → continuous-dev (latest dev build, tracks dev branch)
-RELEASE_TAG="v2.4.0"
+RELEASE_TAG="continuous"
 FLATPAK_FILENAME="org.bootcinstaller.Installer.flatpak"
-# NOTE: Do NOT change stable back to "continuous" — that rolling release was
-# silently updated 2026-05-09 with v2.5.0 which contains the broken overlay
-# storage code path. Pinned to v2.4.0 until tuna-os/fisherman#38 is resolved.
 if [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]]; then
     RELEASE_TAG="continuous-dev"
     FLATPAK_FILENAME="org.bootcinstaller.Installer.Devel.flatpak"


### PR DESCRIPTION
Summary: restore stable installer channel to use the current prod build by unpinning from v2.4.0. Change: set RELEASE_TAG in dakota/src/install-flatpaks.sh from v2.4.0 to continuous; keep dev channel on continuous-dev. Why: makes dakota-iso stable builds consume the latest tuna-os/tuna-installer prod build instead of a pinned historical tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Installer now defaults to rolling/continuous releases so installers fetched during installation stay up-to-date rather than pinned to a specific version.
* **Tests**
  * CI end-to-end test runner adjusted to locate and invoke the test helper with elevated permissions to improve reliability of LUKS QEMU tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota-iso/pull/32)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->