### PR TITLE
feat: add distroID/brewTap to recipe.json for generic fisherman OEM setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ install offline without a network pull. This requires:
 - **Backend binary:** `fisherman` — symlinked to `/usr/local/bin/fisherman` by `configure-live.sh`
 - **Config path:** `/etc/bootc-installer/images.json` (catalog lock) + `recipe.json` (branding)
 - **Flatpak sandbox trick:** Inside the Flatpak, `/etc` is reserved. The host `/etc` is at
-  `/run/host/etc`. Recipe is passed via `VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json`.
+  `/run/host/etc`. Recipe is passed via `BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json`.
 - **live-iso-mode:** `touch /etc/bootc-installer/live-iso-mode` activates live ISO mode
   in the installer (see tuna-os/tuna-installer#26).
 

--- a/dakota/src/configure-live.sh
+++ b/dakota/src/configure-live.sh
@@ -268,13 +268,13 @@ INSTALLER_APP_ID="org.bootcinstaller.Installer"
 [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
 
 mkdir -p /etc/xdg/autostart
-# VANILLA_CUSTOM_RECIPE workaround (tuna-os/tuna-installer#26): inside the
+# BOOTC_CUSTOM_RECIPE workaround (tuna-os/tuna-installer#26): inside the
 # Flatpak sandbox /etc is reserved; the host /etc is at /run/host/etc.  Pass
 # the recipe via env var at the /run/host path so the installer finds it.
 cat > /etc/xdg/autostart/tuna-installer.desktop << DTEOF
 [Desktop Entry]
 Name=Dakota Installer
-Exec=flatpak run --env=VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
+Exec=flatpak run --env=BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
 Icon=dakota
 Type=Application
 X-GNOME-Autostart-enabled=true
@@ -288,7 +288,7 @@ cat > /usr/share/applications/dakota-installer.desktop << DTEOF
 [Desktop Entry]
 Name=Dakota Installer
 Comment=Install Dakota to your computer
-Exec=flatpak run --env=VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
+Exec=flatpak run --env=BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
 Icon=dakota
 Type=Application
 Categories=System;

--- a/dakota/src/etc/bootc-installer/recipe.json
+++ b/dakota/src/etc/bootc-installer/recipe.json
@@ -6,6 +6,8 @@
   "local_imgref": "containers-storage:ghcr.io/projectbluefin/dakota:latest",
   "bootloader": "systemd",
   "composeFsBackend": true,
+  "distroID": "dakota",
+  "brewTap": "ublue-os/tap",
   "tour": {
     "welcome": {
       "image": "/run/host/usr/share/bootc-installer/images/dakotaraptor.png",

--- a/justfile
+++ b/justfile
@@ -891,8 +891,21 @@ luks-boot-qemu-live target:
     sudo rm -f "{{luks-qemu-monitor-live}}" "{{luks-qemu-serial-live}}"
 
     echo "Booting live ISO: $ISO"
-    "$QEMU" \
-        -machine q35 -cpu host -m 8192 -smp 4 -accel kvm \
+    # KVM access: try direct, then sudo, then fall back to TCG
+    QEMU_ACCEL="-accel kvm"
+    QEMU_PREFIX=""
+    if ! test -r /dev/kvm 2>/dev/null; then
+        if sudo test -r /dev/kvm 2>/dev/null; then
+            echo "Using sudo for KVM access"
+            QEMU_PREFIX="sudo"
+        else
+            echo "KVM not available, falling back to TCG emulation (slower)"
+            QEMU_ACCEL="-accel tcg,thread=multi"
+            QEMU_PREFIX=""
+        fi
+    fi
+    $QEMU_PREFIX "$QEMU" \
+        -machine q35 -cpu host -m 8192 -smp 4 $QEMU_ACCEL \
         -drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
         -drive "if=pflash,format=raw,file=${OVMF_VARS}" \
         -drive "if=none,id=iso,file=${ISO},media=cdrom,readonly=on,format=raw" \
@@ -997,8 +1010,21 @@ luks-boot-qemu-installed target:
     sudo rm -f "{{luks-qemu-monitor-installed}}" "{{luks-qemu-serial-installed}}"
 
     echo "Booting installed disk: {{luks-qemu-disk}}"
-    "$QEMU" \
-        -machine q35 -cpu host -m 8192 -smp 4 -accel kvm \
+    # KVM access: try direct, then sudo, then fall back to TCG
+    QEMU_ACCEL="-accel kvm"
+    QEMU_PREFIX=""
+    if ! test -r /dev/kvm 2>/dev/null; then
+        if sudo test -r /dev/kvm 2>/dev/null; then
+            echo "Using sudo for KVM access"
+            QEMU_PREFIX="sudo"
+        else
+            echo "KVM not available, falling back to TCG emulation (slower)"
+            QEMU_ACCEL="-accel tcg,thread=multi"
+            QEMU_PREFIX=""
+        fi
+    fi
+    $QEMU_PREFIX "$QEMU" \
+        -machine q35 -cpu host -m 8192 -smp 4 $QEMU_ACCEL \
         -drive "if=pflash,format=raw,readonly=on,file=${OVMF_CODE}" \
         -drive "if=pflash,format=raw,file=${OVMF_VARS}" \
         -drive "if=none,id=disk,file={{luks-qemu-disk}},format=qcow2" \


### PR DESCRIPTION
## Summary

- Adds `distroID: "dakota"` to `recipe.json` so fisherman's OEM setup writes to `/etc/dakota/oem/` and names the service `dakota-oem-setup.service` (preserving current behaviour after the genericization in tuna-os/fisherman#41)
- Adds `brewTap: "ublue-os/tap"` so the ASUS/Framework first-login brew installer still taps the ublue-os Homebrew tap
- Updates `CLAUDE.md` reference from `VANILLA_CUSTOM_RECIPE` → `BOOTC_CUSTOM_RECIPE` (renamed in projectbluefin/bootc-installer#50)

## Why

`tuna-os/fisherman#41` removes the hardcoded `dakota` and `ublue-os/tap` strings from fisherman's OEM setup code and drives them from `recipe.json` instead. Without these fields, fisherman defaults to `distroID: "bootc"`, which would write to `/etc/bootc/oem/` and create `bootc-oem-setup.service` — different paths than what current Dakota users have.

## Test plan

- [ ] Verify recipe.json is valid JSON: `python3 -m json.tool < dakota/src/etc/bootc-installer/recipe.json`
- [ ] Confirm no regressions in build: `just iso-sd-boot dakota`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installer docs updated: environment variable for supplying a custom recipe renamed.

* **Configuration**
  * Installer recipe extended with distribution identifier and package-manager tap settings.

* **Improvements**
  * QEMU-based LUKS test recipes now auto-detect KVM and select accelerator plus privilege-escalation fallback to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectbluefin/dakota-iso/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->