### PR TITLE
docs: fix env var name consistency — VANILLA_CUSTOM_RECIPE → BOOTC_CUSTOM_RECIPE

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ Requirements:
 - **Backend binary:** `fisherman` → symlinked to `/usr/local/bin/fisherman` by `configure-live.sh`
 - **Config:** `/etc/bootc-installer/images.json` (catalog) + `recipe.json` (branding)
 - **Flatpak sandbox:** Inside the Flatpak, `/etc` is reserved. Host `/etc` is at `/run/host/etc`.
-  Recipe passed via `VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json`.
+  Recipe passed via `BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json`.
 - **live-iso-mode:** `touch /etc/bootc-installer/live-iso-mode` activates live ISO mode
   in the installer.
 


### PR DESCRIPTION
## Summary

Fixes stale env var reference in docs after PR #40 renamed the variable.

Closes #41

### Changes
- `docs/architecture.md`: `VANILLA_CUSTOM_RECIPE` → `BOOTC_CUSTOM_RECIPE`
- All code references (CLAUDE.md, configure-live.sh) already use the correct name

## Test plan
- [ ] Verify docs/architecture.md renders correctly