### PR TITLE
fix(luks-e2e): wait for live boot GUI to stabilize before screenshot

### DIFF
--- a/.github/workflows/test-luks-install.yml
+++ b/.github/workflows/test-luks-install.yml
@@ -28,6 +28,27 @@ permissions:
   actions: read
 
 jobs:
+  unit-tests:
+    name: Python Unit Tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run unit tests
+        run: |
+          pytest tests/
+
   luks-e2e:
     name: LUKS E2E (${{ matrix.installer_channel }})
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-luks-install.yml
+++ b/.github/workflows/test-luks-install.yml
@@ -41,7 +41,9 @@ jobs:
           python-version: '3.12'
 
       - name: Install just
-        uses: taiki-e/install-action@just
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1 (just)
+        with:
+          tool: just
 
       - name: Run unit tests
         run: just test

--- a/.github/workflows/test-luks-install.yml
+++ b/.github/workflows/test-luks-install.yml
@@ -40,14 +40,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
+      - name: Install just
+        uses: taiki-e/install-action@just
 
       - name: Run unit tests
-        run: |
-          pytest tests/
+        run: just test
 
   luks-e2e:
     name: LUKS E2E (${{ matrix.installer_channel }})

--- a/dakota/src/luks-unlock.py
+++ b/dakota/src/luks-unlock.py
@@ -12,8 +12,9 @@ Plymouth prompt by analysing QEMU screendumps (PPM files):
   - Then inject keystrokes via virsh send-key (libvirt) or QEMU HMP sendkey.
 
 Usage:
-  libvirt mode:  luks-unlock.py libvirt <vm-name> <passphrase> <mac-address>
-  qemu mode:     luks-unlock.py qemu    <monitor-sock> <passphrase> <serial-log>
+  libvirt mode:   luks-unlock.py libvirt   <vm-name> <passphrase> <mac-address>
+  qemu mode:      luks-unlock.py qemu      <monitor-sock> <passphrase> <serial-log>
+  wait-live mode: luks-unlock.py wait-live <monitor-sock> <screenshot-path>
 
 Exit codes:
   0 — passphrase sent and boot succeeded (display re-stabilised after unlock)
@@ -420,6 +421,65 @@ def run_qemu(monitor_sock: str, passphrase: str, serial_log: str):
     sys.exit(2)
 
 
+def run_wait_live(monitor_sock: str, screenshot_path: str):
+    """Wait for the live boot screen to become bright and stable.
+
+    This ensures that when we capture the live-boot screenshot for CI/PR
+    diagnostics, the installer GUI (or at least a fully rendered desktop)
+    is actually loaded and visible, rather than just a black screen or
+    a transitional boot logo.
+    """
+    print(f"[luks-unlock] wait-live mode — watching monitor {monitor_sock}...", flush=True)
+
+    CONTENT_THRESHOLD = 1.5
+    STABLE_POLLS      = 2
+    POLL_INTERVAL     = 3
+    # Wait up to 5 minutes (300 seconds) for the GUI to load and stabilize
+    timeout = time.time() + 300
+
+    stable_count = 0
+    prev_hash = ""
+    snap = "/tmp/luks-live-boot-snap.ppm"
+
+    while time.time() < timeout:
+        brightness, md5 = qemu_screendump(monitor_sock, snap)
+        print(f"[luks-unlock] wait-live: brightness={brightness:.2f} hash={md5[:8]}", flush=True)
+
+        if brightness < 0:
+            # Screendump failed (socket not ready, etc.)
+            stable_count = 0
+            time.sleep(POLL_INTERVAL)
+            continue
+
+        # Is the screen bright enough?
+        if brightness >= CONTENT_THRESHOLD:
+            # Yes! Save the md5 and let's check stability.
+            if md5 == prev_hash:
+                stable_count += 1
+            else:
+                stable_count = 0
+            prev_hash = md5
+
+            # Keep a backup of the latest bright screenshot in case we time out
+            try:
+                import shutil
+                shutil.copy2(snap, screenshot_path)
+            except OSError:
+                pass
+
+            if stable_count >= STABLE_POLLS:
+                print(f"[luks-unlock] Live boot GUI stable (brightness={brightness:.2f}, {stable_count} identical polls)", flush=True)
+                return
+        else:
+            # Screen is dark/black (boot splash, blank screen, or screen saver)
+            stable_count = 0
+            prev_hash = ""
+
+        time.sleep(POLL_INTERVAL)
+
+    print("[luks-unlock] WARNING: wait-live timed out or screen never stabilized. Using last captured screen.", file=sys.stderr)
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 def main():
@@ -441,8 +501,14 @@ def main():
             sys.exit(1)
         run_qemu(sys.argv[2], sys.argv[3], sys.argv[4])
 
+    elif mode == "wait-live":
+        if len(sys.argv) < 4:
+            print("Usage: luks-unlock.py wait-live <monitor-sock> <screenshot-path>", file=sys.stderr)
+            sys.exit(1)
+        run_wait_live(sys.argv[2], sys.argv[3])
+
     else:
-        print(f"Unknown mode: {mode!r}. Use 'libvirt' or 'qemu'.", file=sys.stderr)
+        print(f"Unknown mode: {mode!r}. Use 'libvirt', 'qemu', or 'wait-live'.", file=sys.stderr)
         sys.exit(1)
 
 

--- a/dakota/src/luks-unlock.py
+++ b/dakota/src/luks-unlock.py
@@ -477,7 +477,10 @@ def run_wait_live(monitor_sock: str, screenshot_path: str):
 
         time.sleep(POLL_INTERVAL)
 
-    print("[luks-unlock] WARNING: wait-live timed out or screen never stabilized. Using last captured screen.", file=sys.stderr)
+    if prev_hash:
+        print("[luks-unlock] WARNING: wait-live timed out — screen never stabilized. Using last captured bright frame.", file=sys.stderr)
+    else:
+        print("[luks-unlock] WARNING: wait-live timed out — screen never reached brightness threshold. No screenshot captured.", file=sys.stderr)
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/docs/luks-testing.md
+++ b/docs/luks-testing.md
@@ -165,3 +165,9 @@ sshpass -p live ssh ... 'setsid bash -c "sudo fisherman recipe.json > /tmp/insta
 
 Polling fisherman completion at 120s intervals causes 2-minute detection gaps.
 Poll at 15s — fisherman takes 5–15 min but the completion check is cheap.
+
+### Live boot screenshot timing in QEMU (2026-06-02)
+
+The live boot screenshot was captured immediately after SSH or the serial ready check succeeded. However, SSH and systemd units start much earlier than GDM autologin and the installer GUI. Capturing the screenshot immediately resulted in a black screen.
+
+Fix: Added `wait-live` mode to `luks-unlock.py` which monitors screen brightness and hash stability. It waits up to 5 minutes for the screen to become bright (brightness >= 1.5) and stable before capturing the PPM.

--- a/justfile
+++ b/justfile
@@ -941,10 +941,10 @@ luks-boot-qemu-live target:
         sleep 5
     done
 
-    # Save a live boot screendump for CI diagnostics / PR comment
-    sleep 2
-    sudo socat - "UNIX-CONNECT:{{luks-qemu-monitor-live}}" \
-        <<< "screendump /tmp/luks-screenshot-live.ppm" 2>/dev/null || true
+    # Wait for the live boot GUI to render and stabilize before taking screenshot
+    sudo python3 "dakota/src/luks-unlock.py" wait-live \
+        "{{luks-qemu-monitor-live}}" \
+        "/tmp/luks-screenshot-live.ppm" || true
 
 # Run fisherman LUKS install via SSH into the live QEMU VM.
 # Reuses the same SSH logic as luks-install; install disk is /dev/vda in QEMU.

--- a/justfile
+++ b/justfile
@@ -1060,3 +1060,7 @@ luks-unlock-qemu target:
         key=$(echo "$label" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
         bash "dakota/src/show-screenshot.sh" "/tmp/luks-screenshot-${key}.ppm" "$label" || true
     done
+
+# Run Python unit tests.
+test:
+    python3 -m unittest discover -s tests

--- a/tests/test_luks_unlock.py
+++ b/tests/test_luks_unlock.py
@@ -297,6 +297,21 @@ class TestLuksUnlock(unittest.TestCase):
         # Should not copy since brightness < threshold
         mock_copy.assert_not_called()
 
+    @patch("luks_unlock.qemu_screendump")
+    @patch("time.sleep")
+    @patch("shutil.copy2")
+    def test_run_wait_live_timeout_with_bright_frame(self, mock_copy, mock_sleep, mock_screendump):
+        # Screen is bright but keeps changing hash
+        mock_screendump.side_effect = [
+            (2.0, 'b'),
+            (2.0, 'c'),
+            (2.0, 'd')
+        ]
+        with patch("time.time", side_effect=[0, 100, 200, 301]):
+            luks_unlock.run_wait_live("/tmp/sock", "/tmp/screenshot.ppm")
+        # Should copy the bright frames
+        self.assertTrue(mock_copy.called)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_luks_unlock.py
+++ b/tests/test_luks_unlock.py
@@ -256,6 +256,47 @@ class TestLuksUnlock(unittest.TestCase):
             mock_run_qemu.assert_called_once_with("/tmp/sock", "pass123", "/tmp/serial.log")
             mock_exit.assert_not_called()
 
+    @patch("sys.exit")
+    def test_main_wait_live_insufficient_args(self, mock_exit):
+        mock_exit.side_effect = SystemExit(1)
+        with patch("sys.argv", ["luks-unlock.py", "wait-live", "/tmp/sock"]):
+            with self.assertRaises(SystemExit):
+                luks_unlock.main()
+            mock_exit.assert_called_once_with(1)
+
+    @patch("sys.exit")
+    @patch("luks_unlock.run_wait_live")
+    def test_main_wait_live_success(self, mock_run_wait_live, mock_exit):
+        with patch("sys.argv", ["luks-unlock.py", "wait-live", "/tmp/sock", "/tmp/screenshot.ppm"]):
+            luks_unlock.main()
+            mock_run_wait_live.assert_called_once_with("/tmp/sock", "/tmp/screenshot.ppm")
+            mock_exit.assert_not_called()
+
+    @patch("luks_unlock.qemu_screendump")
+    @patch("time.sleep")
+    @patch("shutil.copy2")
+    def test_run_wait_live_success(self, mock_copy, mock_sleep, mock_screendump):
+        mock_screendump.side_effect = [
+            (0.1, 'a'),
+            (2.0, 'b'),
+            (2.0, 'b'),
+            (2.0, 'b')
+        ]
+        luks_unlock.run_wait_live("/tmp/sock", "/tmp/screenshot.ppm")
+        self.assertEqual(mock_screendump.call_count, 4)
+        mock_copy.assert_called_with("/tmp/luks-live-boot-snap.ppm", "/tmp/screenshot.ppm")
+
+    @patch("luks_unlock.qemu_screendump")
+    @patch("time.sleep")
+    @patch("shutil.copy2")
+    def test_run_wait_live_timeout(self, mock_copy, mock_sleep, mock_screendump):
+        # Always dark, or never stable
+        mock_screendump.return_value = (0.1, 'a')
+        with patch("time.time", side_effect=[0, 100, 200, 301]):
+            luks_unlock.run_wait_live("/tmp/sock", "/tmp/screenshot.ppm")
+        # Should not copy since brightness < threshold
+        mock_copy.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_luks_unlock.py
+++ b/tests/test_luks_unlock.py
@@ -1,0 +1,261 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+
+# Dynamically import luks-unlock.py which has a hyphen in its name
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "luks_unlock",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "../dakota/src/luks-unlock.py"))
+)
+luks_unlock = importlib.util.module_from_spec(spec)
+sys.modules["luks_unlock"] = luks_unlock
+spec.loader.exec_module(luks_unlock)
+
+
+class TestLuksUnlock(unittest.TestCase):
+
+    # ── qemu_check_serial Tests ────────────────────────────────────────────────
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_qemu_check_serial_file_not_found(self, mock_file):
+        # If the file does not exist, it should return "" gracefully
+        mock_file.side_effect = FileNotFoundError()
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="Please enter passphrase for disk /dev/vda:")
+    def test_qemu_check_serial_plymouth(self, mock_file):
+        # Check that it identifies "plymouth" passphrase prompt
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "plymouth")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="[  OK  ] Started gdm.service - GNOME Display Manager.")
+    def test_qemu_check_serial_gdm_started(self, mock_file):
+        # Check that it identifies "gdm" when service starts
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "gdm")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="Started GNOME Display Manager.")
+    def test_qemu_check_serial_gdm_display_manager(self, mock_file):
+        # Check that it identifies "gdm" with alternate display manager string
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "gdm")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="\x1b[1;31m  OK  ] Started \x1b[0m\ngdm.service\n- GNOME Display…")
+    def test_qemu_check_serial_gdm_with_ansi_escapes(self, mock_file):
+        # Check that it strips ANSI escape codes and collapses whitespace
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "gdm")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="[  OK  ] Started gnome-initial-setup.service - GNOME Initial Setup.")
+    def test_qemu_check_serial_gnome_initial_setup(self, mock_file):
+        # Check that it identifies "gnome-initial-setup"
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "gnome-initial-setup")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="Entering emergency mode. Exit shell to continue.")
+    def test_qemu_check_serial_emergency_mode(self, mock_file):
+        # Check that it identifies "emergency"
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "emergency")
+
+    @patch("builtins.open", new_callable=mock_open, read_data="Some other boot log lines with no markers...")
+    def test_qemu_check_serial_no_marker(self, mock_file):
+        # Check that it returns empty string if no markers are present
+        result = luks_unlock.qemu_check_serial("dummy.log")
+        self.assertEqual(result, "")
+
+    # ── virsh_dhcp_ip Tests ────────────────────────────────────────────────────
+
+    @patch("subprocess.run")
+    def test_virsh_dhcp_ip_found(self, mock_run):
+        # Mock subprocess to return lease table output
+        mock_proc = MagicMock()
+        mock_proc.stdout = (
+            " Expiry Time          MAC address        Protocol  IP address                Hostname        Client ID or DUID\n"
+            "-------------------------------------------------------------------------------------------------------------------\n"
+            " 2026-05-31 15:00:00  52:54:00:fa:12:34  ipv4      192.168.122.42/24         dakota-vm       01:52:54:00:fa:12:34\n"
+        )
+        mock_run.return_value = mock_proc
+
+        result = luks_unlock.virsh_dhcp_ip("52:54:00:fa:12:34")
+        self.assertEqual(result, "192.168.122.42")
+
+        # Verify case insensitivity
+        result_caps = luks_unlock.virsh_dhcp_ip("52:54:00:FA:12:34")
+        self.assertEqual(result_caps, "192.168.122.42")
+
+    @patch("subprocess.run")
+    def test_virsh_dhcp_ip_not_found(self, mock_run):
+        mock_proc = MagicMock()
+        mock_proc.stdout = (
+            " Expiry Time          MAC address        Protocol  IP address                Hostname        Client ID or DUID\n"
+            "-------------------------------------------------------------------------------------------------------------------\n"
+            " 2026-05-31 15:00:00  52:54:00:fa:12:34  ipv4      192.168.122.42/24         dakota-vm       01:52:54:00:fa:12:34\n"
+        )
+        mock_run.return_value = mock_proc
+
+        result = luks_unlock.virsh_dhcp_ip("00:11:22:33:44:55")
+        self.assertEqual(result, "")
+
+    # ── virsh_send_passphrase Tests ────────────────────────────────────────────
+
+    @patch("time.sleep")  # Patch sleep so tests run instantly
+    @patch("subprocess.run")
+    def test_virsh_send_passphrase_valid(self, mock_run, mock_sleep):
+        luks_unlock.virsh_send_passphrase("myvm", "abc-1")
+
+        # abc-1 translates to KEY_A, KEY_B, KEY_C, KEY_MINUS, KEY_1, followed by KEY_ENTER
+        expected_calls = [
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_A"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_B"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_C"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_MINUS"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_1"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_ENTER"],)
+        ]
+
+        # Extract only call arguments
+        actual_calls = [call[0] for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_virsh_send_passphrase_edge_cases(self, mock_run, mock_sleep):
+        # Test spaces, underscores, uppercase (skipped) and special chars (skipped)
+        luks_unlock.virsh_send_passphrase("myvm", "a_B $")
+
+        # 'a' -> KEY_A
+        # '_' -> KEY_MINUS
+        # 'B' -> skipped (only lowercase is mapped in key_map)
+        # ' ' -> KEY_SPACE
+        # '$' -> skipped
+        # Always followed by KEY_ENTER
+        expected_calls = [
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_A"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_MINUS"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_SPACE"],),
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_ENTER"],)
+        ]
+        actual_calls = [call[0] for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_virsh_send_passphrase_empty(self, mock_run, mock_sleep):
+        # Empty passphrase should only send KEY_ENTER
+        luks_unlock.virsh_send_passphrase("myvm", "")
+        expected_calls = [
+            (["virsh", "send-key", "myvm", "--codeset", "linux", "KEY_ENTER"],)
+        ]
+        actual_calls = [call[0] for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    # ── qemu_send_passphrase Tests ────────────────────────────────────────────
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_qemu_send_passphrase_valid(self, mock_run, mock_sleep):
+        luks_unlock.qemu_send_passphrase("/tmp/sock", "abc-1")
+
+        # abc-1 translates to keys: a, b, c, minus, 1, followed by ret
+        expected_calls = [
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey a\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey b\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey c\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey minus\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey 1\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey ret\n")
+        ]
+
+        actual_calls = [(call[0][0], call[1].get("input")) for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_qemu_send_passphrase_edge_cases(self, mock_run, mock_sleep):
+        # Test spaces, underscores, uppercase (skipped) and special chars (skipped)
+        luks_unlock.qemu_send_passphrase("/tmp/sock", "a_B $")
+
+        # 'a' -> a
+        # '_' -> shift-minus
+        # 'B' -> skipped (uppercase not in map)
+        # ' ' -> spc
+        # '$' -> skipped
+        # Always followed by ret
+        expected_calls = [
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey a\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey shift-minus\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey spc\n"),
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey ret\n")
+        ]
+        actual_calls = [(call[0][0], call[1].get("input")) for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    @patch("time.sleep")
+    @patch("subprocess.run")
+    def test_qemu_send_passphrase_empty(self, mock_run, mock_sleep):
+        # Empty passphrase should only send ret
+        luks_unlock.qemu_send_passphrase("/tmp/sock", "")
+        expected_calls = [
+            (["socat", "-", "UNIX-CONNECT:/tmp/sock"], b"sendkey ret\n")
+        ]
+        actual_calls = [(call[0][0], call[1].get("input")) for call in mock_run.call_args_list]
+        self.assertEqual(actual_calls, expected_calls)
+
+    # ── main() Routing Tests ───────────────────────────────────────────────────
+
+    @patch("sys.exit")
+    def test_main_no_args(self, mock_exit):
+        mock_exit.side_effect = SystemExit(1)
+        with patch("sys.argv", ["luks-unlock.py"]):
+            with self.assertRaises(SystemExit):
+                luks_unlock.main()
+            mock_exit.assert_called_once_with(1)
+
+    @patch("sys.exit")
+    def test_main_invalid_mode(self, mock_exit):
+        mock_exit.side_effect = SystemExit(1)
+        with patch("sys.argv", ["luks-unlock.py", "invalid_mode"]):
+            with self.assertRaises(SystemExit):
+                luks_unlock.main()
+            mock_exit.assert_called_once_with(1)
+
+    @patch("sys.exit")
+    def test_main_libvirt_insufficient_args(self, mock_exit):
+        mock_exit.side_effect = SystemExit(1)
+        with patch("sys.argv", ["luks-unlock.py", "libvirt", "vm-name"]):
+            with self.assertRaises(SystemExit):
+                luks_unlock.main()
+            mock_exit.assert_called_once_with(1)
+
+    @patch("sys.exit")
+    def test_main_qemu_insufficient_args(self, mock_exit):
+        mock_exit.side_effect = SystemExit(1)
+        with patch("sys.argv", ["luks-unlock.py", "qemu", "/tmp/sock"]):
+            with self.assertRaises(SystemExit):
+                luks_unlock.main()
+            mock_exit.assert_called_once_with(1)
+
+    @patch("sys.exit")
+    @patch("luks_unlock.run_libvirt")
+    def test_main_libvirt_success(self, mock_run_libvirt, mock_exit):
+        with patch("sys.argv", ["luks-unlock.py", "libvirt", "myvm", "pass123", "52:54:00:fa:12:34"]):
+            luks_unlock.main()
+            mock_run_libvirt.assert_called_once_with("myvm", "pass123", "52:54:00:fa:12:34")
+            mock_exit.assert_not_called()
+
+    @patch("sys.exit")
+    @patch("luks_unlock.run_qemu")
+    def test_main_qemu_success(self, mock_run_qemu, mock_exit):
+        with patch("sys.argv", ["luks-unlock.py", "qemu", "/tmp/sock", "pass123", "/tmp/serial.log"]):
+            luks_unlock.main()
+            mock_run_qemu.assert_called_once_with("/tmp/sock", "pass123", "/tmp/serial.log")
+            mock_exit.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses the issue where the live boot screenshot in the LUKS E2E test PR comment is always a black screen.

### Problem
The live boot screenshot in the `luks-boot-qemu-live` recipe was captured immediately after the serial marker `DAKOTA_LIVE_READY` or SSH connection succeeded. However, SSH and systemd services start much earlier than GDM autologin and the installer GUI. Capturing the screenshot immediately resulted in a black screen.

### Changes
1. **New `wait-live` Mode in `luks-unlock.py`**:
   - Added a new mode (`wait-live`) to `luks-unlock.py` that monitors screen brightness and hash stability.
   - It polls QEMU's monitor screendump and waits up to 5 minutes for the screen to become bright (average pixel brightness >= 1.5) and stable (identical hashes for 2 consecutive polls, ~6s).
   - If the timeout is reached or stability is not achieved, it falls back to copying the last captured screen.
2. **Updated `justfile`**:
   - Updated the `luks-boot-qemu-live` recipe to call `luks-unlock.py wait-live` instead of running `screendump` directly.
3. **Unit Tests**:
   - Added CLI routing tests and logic mocks for the `wait-live` mode to `test_luks_unlock.py`.
4. **Documentation**:
   - Added a lesson explaining this issue and the fix to `docs/luks-testing.md`.

*Note: This is a stacked PR on top of #52 (tests/luks-unlock-51) as it includes and tests functions on top of that branch's unit tests.*

- [x] I am using an agent and I take responsibility for this PR
