### PR TITLE
ci: add ShellCheck workflow for shell script linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: warning
+          scandir: '.'
+          ignore_paths: >
+            .git

--- a/dakota/src/build-iso.sh
+++ b/dakota/src/build-iso.sh
@@ -34,6 +34,7 @@ OUTPUT_ISO="${3:?Usage: build-iso.sh <boot-files-tar> <squashfs-img> <output-iso
 LABEL="DAKOTA_LIVE"
 
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/iso-build.XXXXXX")
+# shellcheck disable=SC2064  # WORK is set above; expanding now is intentional
 trap "chmod -R u+rwX '${WORK}' 2>/dev/null; rm -rf '${WORK}'" EXIT
 
 BOOT_DIR="${WORK}/boot-files"

--- a/dakota/src/dracut/95dakota-isofile/module-setup.sh
+++ b/dakota/src/dracut/95dakota-isofile/module-setup.sh
@@ -19,5 +19,6 @@ installkernel() {
 
 install() {
     inst_multiple mount umount blkid losetup find grep sed mkdir ln readlink basename cat sleep udevadm
+    # shellcheck disable=SC2154  # moddir is provided by the dracut runtime environment
     inst_hook initqueue 20 "$moddir/dakota-isofile.sh"
 }

--- a/dakota/src/install-flatpaks.sh
+++ b/dakota/src/install-flatpaks.sh
@@ -90,7 +90,7 @@ for app in "${INSTALLED[@]}"; do
     # Keep the installer regardless (stable or devel app ID)
     [[ "$app" == "org.bootcinstaller.Installer" ]] && continue
     [[ "$app" == "org.bootcinstaller.Installer.Devel" ]] && continue
-    if [[ ! " ${WANTED[*]} " =~ " ${app} " ]]; then
+    if [[ ! " ${WANTED[*]} " == *" ${app} "* ]]; then
         echo "Removing dropped flatpak: $app"
         flatpak uninstall --system --noninteractive "$app" || true
     fi

--- a/live/src/build-iso.sh
+++ b/live/src/build-iso.sh
@@ -46,6 +46,7 @@ OUTPUT_ISO="${3:?Usage: build-iso.sh [--store <store-squashfs>] <boot-files-tar>
 LABEL="DAKOTA_LIVE"
 
 WORK=$(mktemp -d "${TMPDIR:-/tmp}/iso-build.XXXXXX")
+# shellcheck disable=SC2064  # WORK is set above; expanding now is intentional
 trap "chmod -R u+rwX '${WORK}' 2>/dev/null; rm -rf '${WORK}'" EXIT
 
 BOOT_DIR="${WORK}/boot-files"

--- a/live/src/dracut/95dakota-isofile/module-setup.sh
+++ b/live/src/dracut/95dakota-isofile/module-setup.sh
@@ -19,5 +19,6 @@ installkernel() {
 
 install() {
     inst_multiple mount umount blkid losetup find grep sed mkdir ln readlink basename cat sleep udevadm
+    # shellcheck disable=SC2154  # moddir is provided by the dracut runtime environment
     inst_hook initqueue 20 "$moddir/dakota-isofile.sh"
 }

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -80,7 +80,7 @@ for app in "${INSTALLED[@]}"; do
     # Keep the installer regardless (stable or devel app ID)
     [[ "$app" == "org.bootcinstaller.Installer" ]] && continue
     [[ "$app" == "org.bootcinstaller.Installer.Devel" ]] && continue
-    if [[ ! " ${WANTED[*]} " =~ " ${app} " ]]; then
+    if [[ ! " ${WANTED[*]} " == *" ${app} "* ]]; then
         echo "Removing dropped flatpak: $app"
         flatpak uninstall --system --noninteractive "$app" || true
     fi


### PR DESCRIPTION
## Summary

Adds a ShellCheck CI job that lints all shell scripts on every PR and push to main. Catches common bugs (unquoted variables, incorrect error handling, portability issues) in installer scripts before they reach users.

### What's included
- New `.github/workflows/lint.yml` with a `shellcheck` job
- Uses `ludeeus/action-shellcheck@2.0.0`
- Severity threshold: `warning` (ignores style/info)
- Scans all `.sh` files in the repository

Closes #54 #57 #58 #60 #61 #62 #63 #64