### PR TITLE
fix(live): sync installer source to projectbluefin/bootc-installer with tuna-os fallback (closes #39)

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -131,3 +131,12 @@ or corrupt ISO that fails to boot. Always use `/var` or an explicit `output_dir`
 in the image config. Dakota/bootc images have no Entrypoint by design; a fake one causes
 `bootc install` to fail with "cannot execute binary file". Always use
 `buildah commit --squash` to squash layers cleanly without touching config.
+
+### live/src/install-flatpaks.sh must mirror dakota/src/install-flatpaks.sh (2026-06)
+
+`live/src/install-flatpaks.sh` is a parallel copy of `dakota/src/install-flatpaks.sh`
+for the live-squashfs build path. When the installer source logic changes in one, it
+must be replicated in the other. After PR fc0346d added primary/fallback logic to the
+`dakota` copy, the `live` copy was left behind still pointing only at `tuna-os/tuna-installer`.
+Both files now use `projectbluefin/bootc-installer` as primary (with `--fail` so curl
+exits non-zero on HTTP errors) and fall back to `tuna-os/tuna-installer` automatically.

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -36,17 +36,27 @@ flatpak remote-add --system --if-not-exists flathub \
 
 # bootc-installer bundle
 # INSTALLER_CHANNEL controls which release tag to pull from:
-#   stable (default) → continuous   (latest stable build from main/prod)
+#   stable (default) → continuous   (latest stable build from prod branch)
 #   dev              → continuous-dev (latest dev build, tracks dev branch)
+# Primary source: projectbluefin/bootc-installer (Project Bluefin's fork).
+# Fallback: tuna-os/tuna-installer (upstream) if projectbluefin assets are unavailable.
+# v2.5.0 includes fisherman v0.2.0 with fix for #38 (OCI cache mount on composefs/btrfs).
+INSTALLER_REPO="projectbluefin/bootc-installer"
+FALLBACK_REPO="tuna-os/tuna-installer"
 RELEASE_TAG="continuous"
 FLATPAK_FILENAME="org.bootcinstaller.Installer.flatpak"
 if [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]]; then
     RELEASE_TAG="continuous-dev"
     FLATPAK_FILENAME="org.bootcinstaller.Installer.Devel.flatpak"
 fi
-curl --retry 3 --location \
-    "https://github.com/tuna-os/tuna-installer/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}" \
-    -o /tmp/tuna-installer.flatpak
+if ! curl --retry 3 --fail --location \
+    "https://github.com/${INSTALLER_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}" \
+    -o /tmp/tuna-installer.flatpak 2>/dev/null; then
+    echo "Primary source unavailable, falling back to ${FALLBACK_REPO}..."
+    curl --retry 3 --fail --location \
+        "https://github.com/${FALLBACK_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}" \
+        -o /tmp/tuna-installer.flatpak
+fi
 INSTALLER_APP_ID="org.bootcinstaller.Installer"
 [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
 


### PR DESCRIPTION
## Summary

`live/src/install-flatpaks.sh` was still pointing directly at `tuna-os/tuna-installer` after `fc0346d` added primary/fallback logic to `dakota/src/install-flatpaks.sh`. This PR syncs the two files.

## Changes

### `live/src/install-flatpaks.sh`

Before:
```bash
curl --retry 3 --location     "https://github.com/tuna-os/tuna-installer/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"     -o /tmp/tuna-installer.flatpak
```

After (matching `dakota/src/install-flatpaks.sh`):
```bash
INSTALLER_REPO="projectbluefin/bootc-installer"
FALLBACK_REPO="tuna-os/tuna-installer"
if ! curl --retry 3 --fail --location     "https://github.com/${INSTALLER_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"     -o /tmp/tuna-installer.flatpak 2>/dev/null; then
    echo "Primary source unavailable, falling back to ${FALLBACK_REPO}..."
    curl --retry 3 --fail --location         "https://github.com/${FALLBACK_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"         -o /tmp/tuna-installer.flatpak
fi
```

Key detail: added `--fail` so a 404/503 response correctly triggers the fallback rather than silently downloading an error HTML page as the flatpak bundle.

### `docs/build.md`

Added a lesson documenting that the two `install-flatpaks.sh` files must be kept in sync.

## Testing

Since `projectbluefin/bootc-installer` `continuous` release still has no assets (CI broken per issue), the fallback to `tuna-os/tuna-installer` will fire at build time — builds continue to succeed. Once bootc-installer CI is fixed and assets are published, the primary will succeed and the fallback will not be reached.

> [ ] I am using an agent and I take responsibility for this PR

Closes #39