### PR TITLE
docs: add testing/lint workflows, fix flatpaks path, note live/src vs dakota/src split

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,9 +143,20 @@ After=display-manager.service   # ordering only
 
 ## Bundled Flatpaks
 
-Pre-installed into the live squashfs at build time. List in `dakota/src/flatpaks`.
+Pre-installed into the live squashfs at build time. List in `live/src/flatpaks`.
 The `install-flatpaks.sh` script uses `--mount=type=cache` to avoid re-downloading
 on rebuilds. The cache is keyed by debug/production mode — switching busts the cache.
+
+## Tests
+
+Unit tests for `luks-unlock.py` live in `tests/test_luks_unlock.py` (52 tests total).
+Run with `pytest tests/ -v`. The `test.yml` CI workflow gates every PR on these tests.
+
+Coverage:
+- `virsh_screenshot_size` — virsh failure, absent file, zero-size file
+- `qemu_screendump` — PPM parsing, brightness calculation, MD5 stability
+- `qemu_check_serial` — ANSI stripping, emergency vs Plymouth priority
+- `virsh_send_passphrase` / `qemu_send_passphrase` — key-name mapping, warnings
 
 ---
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -90,7 +90,22 @@ the image to one layer before VFS import. The squash uses `buildah from --pull-n
 + `buildah commit --squash` — NOT `podman create --entrypoint ... && podman commit`
 (the latter corrupts the Entrypoint config, breaking `bootc install`).
 
-## Boot testing locally
+## Source layout: `live/src/` vs `dakota/src/`
+
+Two parallel source trees exist:
+
+| Path | Used by | Notes |
+|---|---|---|
+| `live/src/` | CI (`build-iso.yml`), `live/Containerfile` | Canonical for CI; `build-iso.sh` here supports `--store` for offline OCI store |
+| `dakota/src/` | Local justfile (`iso-sd-boot`, `luks-*` recipes) | `build-iso.sh` here is the simpler local variant without `--store` |
+
+The live container (`live/Containerfile`) is used for **both** local and CI builds.
+`live/src/flatpaks` is the definitive list of bundled Flatpaks.
+
+`dakota/src/flatpaks` is a legacy copy — it may diverge. Use `live/src/flatpaks` as the
+source of truth when adding or removing apps.
+
+
 
 ```bash
 # Quick headless QEMU test — watch for DAKOTA_LIVE_READY on serial (Ctrl-A X to quit)
@@ -119,7 +134,12 @@ just debug=1 boot-libvirt-debug dakota
 
 ## Lessons
 
-### Never build on /tmp — it fills silently and corrupts output (2026-05)
+### `dakota/src/flatpaks` diverged from `live/src/flatpaks` (2026-06)
+
+`dakota/src/flatpaks` contains `be.alexandervanhee.gradia` but `live/src/flatpaks` does not.
+Since `live/Containerfile` uses `live/src/flatpaks`, CI builds omit Gradia. Keep `live/src/flatpaks`
+as the source of truth and sync `dakota/src/flatpaks` to match it.
+
 
 `/tmp` is a 16 GB tmpfs on this host. A Dakota build needs ~22 GB peak. The build
 does not fail immediately — it runs out of space mid-squash and produces a truncated

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,6 +8,8 @@ How the GitHub Actions workflows build, test, and publish Dakota ISOs.
 |---|---|---|
 | Build & Publish | `build-iso.yml` | push to main, daily 03:00 UTC, `workflow_dispatch` |
 | LUKS E2E Test | `test-luks-install.yml` | PRs to main, weekly Mon 04:00 UTC, `workflow_dispatch` |
+| ShellCheck Lint | `lint.yml` | PRs to main, push to main |
+| Python Unit Tests | `test.yml` | PRs to main, push to main |
 
 ## build-iso.yml
 
@@ -108,6 +110,29 @@ All workflow files go in `.github/workflows/`. Before adding:
 - Run `actionlint` (config in `.github/actionlint.yaml`)
 - Check matrix `fail-fast: false` for variant builds
 - Do not use `installer_channel=dev` in scheduled/release builds
+
+## lint.yml — ShellCheck
+
+Runs ShellCheck on every `.sh` file in the repository. Severity threshold is `warning`
+(style/info is ignored). Uses `ludeeus/action-shellcheck@2.0.0`.
+
+Any new shell script must pass ShellCheck before merge. For intentional suppression,
+add an inline `# shellcheck disable=SCxxxx` comment with a justification.
+
+## test.yml — Python Unit Tests
+
+Runs `pytest tests/ -v` against Python 3.11. Tests live in `tests/test_luks_unlock.py`
+and cover `live/src/luks-unlock.py` (also mirrored at `dakota/src/luks-unlock.py`):
+- virsh screenshot size (5 tests)
+- QEMU screendump PPM parsing (9 tests)
+- Serial log parsing edge cases (5 tests)
+- Passphrase injection key-name logic (6 tests)
+
+Run locally with:
+```bash
+pip install pytest
+pytest tests/ -v
+```
 
 ---
 


### PR DESCRIPTION
## What this PR does

Updates documentation to reflect the repo state after merging PRs #65 (ShellCheck CI) and #66 (pytest CI).

### Changes

**docs/ci.md**
- Add `lint.yml` and `test.yml` to the Workflows table
- Add dedicated sections for ShellCheck and pytest workflows, including local run instructions

**docs/architecture.md**
- Fix Bundled Flatpaks path: `dakota/src/flatpaks` → `live/src/flatpaks` (the live Containerfile uses `live/src/`)
- Add Tests section documenting `tests/test_luks_unlock.py` coverage areas

**docs/build.md**
- Add Source layout section clarifying `live/src/` (CI/Containerfile) vs `dakota/src/` (local justfile) duality
- Note `live/src/flatpaks` as source of truth
- Add lesson about the `gradia` Flatpak divergence between the two trees

---

- [ ] I am using an agent and I take responsibility for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with clarified Bundled Flatpaks location and expanded test section
  * Added source layout guidance clarifying which code sources are authoritative for CI versus local builds
  * Documented ShellCheck lint and Python unit test CI workflows with execution details and local run instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->