### PR TITLE
docs: update for multi-arch ISO merge (PR #70)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,11 @@ Runs on the host (not inside a container). Assembles the final ISO from the expo
 of a build container and allow the justfile to control output paths directly.
 xorriso available via brew at `/home/linuxbrew/.linuxbrew/bin/xorriso`.
 
+**Multi-arch support:** Pass `--arch <arch>:<boot-tar>:<squashfs>` (repeatable) to produce
+a single fat-ESP ISO with per-arch kernels, initramfs images, squashfs rootfs images, and both
+`BOOTX64.EFI` + `BOOTAA64.EFI`. Single-arch positional-arg invocation is unchanged.
+See `docs/multi-arch.md` for design rationale and size estimates.
+
 ## ISO layout
 
 ```
@@ -149,14 +154,18 @@ on rebuilds. The cache is keyed by debug/production mode — switching busts the
 
 ## Tests
 
-Unit tests for `luks-unlock.py` live in `tests/test_luks_unlock.py` (52 tests total).
-Run with `pytest tests/ -v`. The `test.yml` CI workflow gates every PR on these tests.
+Unit tests live in `tests/` and run via `pytest tests/ -v` (gated on every PR by `test.yml`).
 
-Coverage:
-- `virsh_screenshot_size` — virsh failure, absent file, zero-size file
-- `qemu_screendump` — PPM parsing, brightness calculation, MD5 stability
-- `qemu_check_serial` — ANSI stripping, emergency vs Plymouth priority
-- `virsh_send_passphrase` / `qemu_send_passphrase` — key-name mapping, warnings
+| File | Tests | Coverage |
+|---|---|---|
+| `tests/test_luks_unlock.py` | 52 | `luks-unlock.py`: virsh/QEMU screenshot, serial parsing, passphrase injection |
+| `tests/test_multi_arch_iso.py` | 4 | `build-iso.sh`: `--arch` flag arg parsing; single-arch + multi-arch ISO integration (skipped if tools absent) |
+
+Run locally:
+```bash
+pip install pytest
+pytest tests/ -v
+```
 
 ---
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -121,12 +121,12 @@ add an inline `# shellcheck disable=SCxxxx` comment with a justification.
 
 ## test.yml — Python Unit Tests
 
-Runs `pytest tests/ -v` against Python 3.11. Tests live in `tests/test_luks_unlock.py`
-and cover `live/src/luks-unlock.py` (also mirrored at `dakota/src/luks-unlock.py`):
-- virsh screenshot size (5 tests)
-- QEMU screendump PPM parsing (9 tests)
-- Serial log parsing edge cases (5 tests)
-- Passphrase injection key-name logic (6 tests)
+Runs `pytest tests/ -v` against Python 3.11.
+
+| File | Tests | Coverage |
+|---|---|---|
+| `tests/test_luks_unlock.py` | 52 | `luks-unlock.py` virsh/QEMU interaction, screenshot parsing, passphrase injection |
+| `tests/test_multi_arch_iso.py` | 4 | `build-iso.sh` `--arch` arg parsing; integration tests (skipped if xorriso/mtools absent) |
 
 Run locally with:
 ```bash

--- a/docs/multi-arch.md
+++ b/docs/multi-arch.md
@@ -1,7 +1,7 @@
 # Multi-Arch ISO (x86_64 + aarch64)
 
 Design document for building a single ISO that boots on both x86_64 and aarch64
-hardware. Tracks issue #36.
+hardware. Implements issue #36 (closed).
 
 ## Current state
 
@@ -101,9 +101,10 @@ Simplest, no dracut changes, already supported upstream.
 
 ## Implementation plan
 
-### Phase 1: `build-iso.sh` multi-arch support (this PR)
+### Phase 1: `build-iso.sh` multi-arch support ✅ Complete
 
-Extend `build-iso.sh` to accept multiple boot-files tars and squashfs images:
+`build-iso.sh` (both `live/src/` and `dakota/src/`) accepts multiple boot-files tars
+and squashfs images via `--arch` flags:
 
 ```bash
 # Current (single-arch):
@@ -124,6 +125,9 @@ When multiple `--arch` flags are provided:
 - Per-arch BLS entries with `rd.live.squashimg=squashfs-<arch>.img`
 - Per-arch squashfs images under `LiveOS/`
 - ESP image sized to fit all architectures
+
+ShellCheck and pytest CI gates pass. See `tests/test_multi_arch_iso.py` for arg-parsing
+and integration tests.
 
 ### Phase 2: Justfile recipes
 
@@ -157,10 +161,12 @@ aarch64 QEMU.
 
 | Blocker | Status | Notes |
 |---|---|---|
-| `rd.live.squashimg` support in dmsquash-live | Supported upstream | Verified in dracut source |
-| aarch64 Dakota images published to GHCR | Blocked | `tuna-os/dakota-x13s` builds exist but may not be on GHCR |
-| Fat ESP with both EFI binaries | Ready | Standard UEFI pattern, no firmware changes needed |
-| CI aarch64 QEMU boot | Ready | TCG emulation works on ubuntu-24.04 runners |
+| `rd.live.squashimg` support in dmsquash-live | ✅ Supported | Verified in dracut source |
+| `build-iso.sh` multi-arch `--arch` flag | ✅ Implemented | Phase 1 complete |
+| aarch64 Dakota images published to GHCR | ⏳ Blocked | `tuna-os/dakota-x13s` builds exist but may not be on GHCR |
+| Fat ESP with both EFI binaries | ✅ Ready | Standard UEFI pattern, no firmware changes needed |
+| Justfile `multi-arch-iso` recipe | ⏳ Not started | Phase 2 |
+| CI aarch64 QEMU boot test | ⏳ Not started | Phase 3; TCG emulation works on ubuntu-24.04 runners |
 
 ## Size estimates
 


### PR DESCRIPTION
Follow-up documentation for PR #70 (multi-arch ISO support, merged).

## Changes

**docs/multi-arch.md**
- Change 'Tracks issue #36' → 'Implements issue #36 (closed)'
- Mark Phase 1 as Complete with a note about ShellCheck/pytest passing and test file added
- Expand Blockers table with clear ✅/⏳ status for each phase

**docs/architecture.md**  
- Add `--arch` flag note to the ISO assembly section with link to `docs/multi-arch.md`
- Replace flat Tests bullet list with a table covering both test files (56 tests total)

**docs/ci.md**
- Replace test.yml bullet list with a structured table showing both test files and test counts

---

- [ ] I am using an agent and I take responsibility for this PR