### PR TITLE
feat(iso): alpha3 — dakota:stable with nvidia_imgref auto-detection

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -69,18 +69,14 @@ jobs:
         run: df -h /
 
       - name: Build live squashfs + boot tar
+        env:
+          SUPERISO_COMPRESSION: release
         run: |
           sudo mkdir -p /var/iso-build
-          sudo bash scripts/build-live-squashfs.sh \
+          sudo -E bash scripts/build-live-squashfs.sh \
             localhost/dakota-nvidia-live:latest \
             /var/iso-build/dakota-nvidia.rootfs.sfs \
             /var/iso-build/dakota-nvidia-boot.tar
-
-      - name: Build offline image store squashfs
-        run: |
-          sudo bash scripts/build-offline-store.sh \
-            /var/iso-build/store.squashfs.img \
-            ghcr.io/projectbluefin/dakota-nvidia:stable
 
       - name: Disk space before ISO assembly
         run: df -h /
@@ -88,7 +84,6 @@ jobs:
       - name: Assemble ISO
         run: |
           sudo bash live/src/build-iso.sh \
-            --store /var/iso-build/store.squashfs.img \
             /var/iso-build/dakota-nvidia-boot.tar \
             /var/iso-build/dakota-nvidia.rootfs.sfs \
             /var/iso-build/dakota-live.iso

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -74,9 +74,24 @@ jobs:
         run: |
           sudo mkdir -p /var/iso-build
           sudo -E bash scripts/build-live-squashfs.sh \
+            --oci-image ghcr.io/projectbluefin/dakota-nvidia:stable \
             localhost/dakota-nvidia-live:latest \
             /var/iso-build/dakota-nvidia.rootfs.sfs \
             /var/iso-build/dakota-nvidia-boot.tar
+
+      - name: Verify offline OCI store is embedded
+        run: |
+          sudo apt-get install -y squashfs-tools -qq
+          # Verify /var/lib/containers/storage is non-empty and contains the expected
+          # image.  An empty store means the offline install will fail (issue #78).
+          COUNT=$(sudo unsquashfs -lc /var/iso-build/dakota-nvidia.rootfs.sfs \
+            var/lib/containers/storage 2>/dev/null | grep -c "ghcr.io" || true)
+          if [[ "${COUNT}" -eq 0 ]]; then
+            echo "ERROR: VFS containers-storage is empty — OCI embedding failed" >&2
+            echo "The ISO would ship without an offline install store (see issue #78)" >&2
+            exit 1
+          fi
+          echo ">>> OCI store assertion passed (${COUNT} ghcr.io refs found)"
 
       - name: Disk space before ISO assembly
         run: df -h /

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -46,12 +46,12 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             sudo podman login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      # Pull both payload images before anything else so they are in the
-      # local podman store when build-offline-store.sh copies them.
+      # Pull nvidia payload image — the only image needed in the offline store.
+      # Non-nvidia users install from this store; their installed system tracks
+      # dakota:stable and rebases on first bootc upgrade automatically.
       - name: Pull offline payload images
         run: |
-          sudo podman pull ghcr.io/projectbluefin/dakota-nvidia:latest
-          sudo podman pull ghcr.io/projectbluefin/dakota:latest
+          sudo podman pull ghcr.io/projectbluefin/dakota-nvidia:stable
 
       # Build only the NVIDIA live container — it's the one that boots live.
       # Non-NVIDIA is available for install via the offline store.
@@ -80,8 +80,7 @@ jobs:
         run: |
           sudo bash scripts/build-offline-store.sh \
             /var/iso-build/store.squashfs.img \
-            ghcr.io/projectbluefin/dakota-nvidia:latest \
-            ghcr.io/projectbluefin/dakota:latest
+            ghcr.io/projectbluefin/dakota-nvidia:stable
 
       - name: Disk space before ISO assembly
         run: df -h /

--- a/.github/workflows/test-luks-install.yml
+++ b/.github/workflows/test-luks-install.yml
@@ -108,32 +108,14 @@ jobs:
           sudo mkdir -p /var/iso-build
           mkdir -p output
 
-          # 1. Build the live container with SSH debug mode enabled
-          sudo podman build \
-            --cap-add sys_admin --security-opt label=disable \
-            --build-arg TARGET=dakota-nvidia \
-            --build-arg DEBUG=1 \
-            --build-arg INSTALLER_CHANNEL=${{ matrix.installer_channel }} \
-            -t localhost/dakota-nvidia-live:latest ./live
-
-          # 2. Export rootfs squashfs + boot files tar
-          sudo bash scripts/build-live-squashfs.sh \
-            localhost/dakota-nvidia-live:latest \
-            /var/iso-build/dakota-nvidia.rootfs.sfs \
-            /var/iso-build/boot.tar
-
-          # 3. Build offline image store (dakota-nvidia is already in root's storage
-          #    from the podman build above — no extra pull needed)
-          sudo bash scripts/build-offline-store.sh \
-            /var/iso-build/store.squashfs.img \
-            ghcr.io/projectbluefin/dakota-nvidia:latest
-
-          # 4. Assemble the UEFI-bootable live ISO with offline store embedded
-          sudo bash live/src/build-iso.sh \
-            --store /var/iso-build/store.squashfs.img \
-            /var/iso-build/boot.tar \
-            /var/iso-build/dakota-nvidia.rootfs.sfs \
-            /var/iso-build/dakota-live.iso
+          # Use just iso-sd-boot — handles container build + VFS store population
+          # + squashfs assembly + ISO assembly in one step.
+          # debug=1 enables SSH for the LUKS install step below.
+          sudo just \
+            debug=1 \
+            installer_channel=${{ matrix.installer_channel }} \
+            output_dir=/var/iso-build \
+            iso-sd-boot dakota
 
           sudo cp /var/iso-build/dakota-live.iso output/dakota-live.iso
           sudo chown -R "$USER:$(id -gn)" output/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,15 @@ gh issue list --repo projectbluefin/dakota-iso --label "queue/agent-ready" --ass
 Read the relevant skill file in `docs/` **before making any changes**.
 Do not assume you know the build system, disk space requirements, or CI constraints.
 
+**Specific triggers — stop and read before acting:**
+
+| Situation | Read first |
+|---|---|
+| Any QEMU boot issue (installed disk won't boot, UEFI shell loop) | [`docs/luks-testing.md`](docs/luks-testing.md) |
+| ISO is unexpectedly large (>6 GB) | [`docs/ci.md`](docs/ci.md) — check for double-embedded store |
+| CI pipeline changes | [`docs/ci.md`](docs/ci.md) |
+| R2 promotion / named releases | [`docs/r2-promotion.md`](docs/r2-promotion.md) |
+
 ### 2. Verification Gate
 
 Before submitting a PR:
@@ -136,12 +145,31 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 just --list        # verify justfile is parseable (no just check target yet)
 ```
 
+### Agent environment constraints
+
+- **`sudo` is not available** in automated agent bash sessions (no TTY). Never call
+  `sudo dd`, `sudo modprobe`, `sudo nbd-client`, etc. If an operation requires root,
+  provide the exact command for the user to run in their terminal instead.
+- **Block device writes** (USB burning, disk inspection via nbd) always require root.
+  Use `udisksctl` for unmounting; provide `dd` / `qemu-nbd` commands for the user to run.
+
+### ISO size invariant
+
+The unified dakota ISO must be **~5.3 GB** with `SUPERISO_COMPRESSION=release`.
+
+- If an ISO is **~8 GB**: the offline OCI store squashfs is being double-embedded.
+  The live container already has the OCI baked in as VFS containers-storage.
+  Do **not** build a separate `store.squashfs.img` or pass `--store` to `build-iso.sh`.
+  See [`docs/ci.md`](docs/ci.md) lessons.
+- If an ISO is **~6–7 GB**: compression is set to `fast` (zstd-3). Use `release` for R2.
+
 ### Sensitive paths (require maintainer review)
 
 - `.github/workflows/` — CI pipeline changes
 - `justfile` — canonical build interface
-- `dakota/src/build-iso.sh` — ISO assembly logic
-- `dakota/src/configure-live.sh` — live environment setup
+- `live/src/build-iso.sh` — ISO assembly logic (canonical; `dakota/src/build-iso.sh` is the local-only copy)
+- `live/src/configure-live.sh` — live environment setup
+- `live/src/install-flatpaks.sh` — Flatpak baking into squashfs
 
 ---
 
@@ -196,6 +224,8 @@ Stop and request human input at these four gates. Never guess past them.
 | **Design** | Architecture change, new subsystem, user-visible behavior change |
 | **Security** | Signing, supply chain, secrets, COPR/third-party sources |
 | **Breakage** | Cross-repo breaking change — removing/renaming inputs, changing defaults |
+| **R2 promotion** | Promoting any ISO to a named release (e.g. `alpha3`) — requires explicit user "go ahead" after local boot verification |
+| **CI trigger on release branch** | Triggering a CI build that will upload to R2 — confirm with user first |
 | **Merge** | PR ready for final review — always requires human `lgtm` |
 
 See [`docs/skills/human-gates.md`](docs/skills/human-gates.md) for full evidence requirements.
@@ -206,6 +236,7 @@ Do not request PR review without evidence:
 
 - [ ] CI is passing (link the run in the PR description)
 - [ ] ISO built and booted (or container-only change — state this explicitly)
+- [ ] ISO size is ~5.3 GB (release compression, no double-embedded store)
 - [ ] Skill file update committed in **this same PR** (not a follow-up)
 - [ ] PR title follows Conventional Commits format
 - [ ] Both AI attribution trailers present on every AI-authored commit

--- a/dakota/live_target
+++ b/dakota/live_target
@@ -1,0 +1,1 @@
+dakota-nvidia

--- a/dakota/payload_ref
+++ b/dakota/payload_ref
@@ -1,1 +1,1 @@
-ghcr.io/projectbluefin/dakota-nvidia:latest
+ghcr.io/projectbluefin/dakota-nvidia:stable

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -14,13 +14,14 @@ Agent entry point for `projectbluefin/dakota-iso`. Load only the skill(s) that m
 | Know when to stop and ask a human | [`docs/skills/human-gates.md`](skills/human-gates.md) |
 | **Building ISOs** | |
 | Build ISOs locally, disk space, BTRFS/XFS quirks | [`docs/build.md`](build.md) |
+| Unified nvidia ISO — size, compression, nvidia_imgref | [`docs/build.md`](build.md) |
 | Add or modify variants (`payload_ref` pattern) | [`docs/variants.md`](variants.md) |
 | **Architecture** | |
 | Two-container pipeline, boot flow, squashfs, VFS storage | [`docs/architecture.md`](architecture.md) |
 | GPT layout, El Torito, systemd-boot, dmsquash-live | [`docs/architecture.md`](architecture.md) |
 | **CI/CD** | |
-| `build-iso.yml`, smoke test, R2 uploads | [`docs/ci.md`](ci.md) |
-| LUKS E2E test (local QEMU, libvirt, CI-equivalent) | [`docs/luks-testing.md`](luks-testing.md) |
+| `build-iso.yml`, smoke test, R2 uploads, unified ISO pipeline | [`docs/ci.md`](ci.md) |
+| LUKS E2E test (local QEMU, libvirt, CI-equivalent) + installed-disk boot | [`docs/luks-testing.md`](luks-testing.md) |
 | **R2 / Release** | |
 | Promoting ISOs to production, rclone, named releases | [`docs/r2-promotion.md`](r2-promotion.md) |
 | **Factory / org** | |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,3 +185,33 @@ Always verify with xorriso `--report_system_area` before shipping an ISO.
 If `driver = "overlay"` is active in `/etc/containers/storage.conf`, the first bootc
 operation creates a `db.sql` that conflicts with VFS metadata. The installer then fails
 to find the embedded OCI image. `configure-live.sh` must explicitly set `driver = "vfs"`.
+
+### nvidia_imgref auto-detection via bootc-installer (2026-06)
+
+bootc-installer v2.6.1 adds `nvidia_imgref` support in `processor.py`.
+When an `images.json` catalog entry has `nvidia_imgref`, the installer auto-detects
+the GPU at install time:
+
+- **NVIDIA GPU present**: installs + tracks `nvidia_imgref`
+- **No NVIDIA GPU**: installs from ISO offline store (nvidia image), but writes
+  `targetImgref = base imgref` into the installed system — so the first `bootc upgrade`
+  rebases to the lighter non-nvidia variant automatically.
+
+**Critical: `recipe.imgref` must be the BASE image (not nvidia)** for
+`_find_nvidia_imgref_for()` to match the `images.json` entry by `imgref`.
+`configure-live.sh` uses `BASE_IMGREF` / `NVIDIA_IMGREF` separately:
+- `recipe["imgref"] = BASE_IMGREF` (matched by processor.py)
+- `recipe["local_imgref"] = "containers-storage:{NVIDIA_IMGREF}"` (offline install source)
+
+**Flatpak path bug in `image.py`** (fixed in projectbluefin/bootc-installer#183):
+`_load_manifest()` was hardcoded to `/etc/bootc-installer/images.json`. Inside a
+Flatpak sandbox, host `/etc` is at `/run/host/etc` — so the live ISO's custom
+`images.json` was never loaded, falling back to the bundled GResource which has no
+`nvidia_imgref`. The fix applies the same `/.flatpak-info` detection already used by
+`RecipeLoader` in `recipe.py`. This PR must land and ship in a new Flatpak release
+for NVIDIA auto-detection to work end-to-end.
+
+**Storage savings from single-image store**:
+`dakota:stable` is NOT needed in the offline store — it's only a tracking ref fetched
+from GHCR on the first `bootc upgrade`. Storing only `dakota-nvidia:stable` saves
+~2.2 GB per ISO (~7.8 GB → ~5.6 GB).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,6 +267,18 @@ Drop-in path: `/etc/systemd/system/bluefin-remove-installer.service.d/live-skip.
 ConditionPathExists=!/etc/bootc-installer/live-iso-mode
 ```
 
+### QEMU installed-disk boot: use qcow2, no cdrom (2026-06)
+
+When verifying an installed system in QEMU (not the live ISO), two things are
+required for OVMF to auto-discover the virtio-blk disk without EFI NVRAM entries:
+
+- Install disk must be **qcow2** format (convert raw → qcow2 with `qemu-img convert` if needed)
+- **No cdrom device** attached — OVMF tries cdrom first and may fail to enumerate virtio-blk
+
+The `luks-boot-qemu-installed` justfile recipe follows this pattern. Boot the serial log
+to confirm — GDM appearing in the log (`Started gdm.service`) is sufficient evidence.
+The GTK window will show GNOME once GDM starts (no additional NVRAM/EFI configuration needed).
+
 ### LUKS E2E CI build pipeline (2026-06)
 
 `test-luks-install.yml` originally used a 4-step manual pipeline:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,14 +6,11 @@ How the Dakota live ISO is assembled and how it boots.
 
 ```
 just iso-sd-boot dakota
-  └─ just container dakota          → builds localhost/dakota-installer (live/Containerfile)
-  └─ just iso-sd-boot (assembly)    → runs dakota/src/build-iso.sh on host
+  └─ just container dakota           → builds localhost/dakota-installer (live/Containerfile)
+  └─ iso-sd-boot (assembly)          → populates VFS store, runs build-iso.sh on host
 
-CI (build-iso.yml) — unified ISO:
-  └─ podman build live/Containerfile  → localhost/dakota-nvidia-live:latest
-  └─ scripts/build-live-squashfs.sh   → dakota-nvidia.rootfs.sfs + boot.tar
-  └─ scripts/build-offline-store.sh   → store.squashfs.img (dakota + dakota-nvidia)
-  └─ live/src/build-iso.sh --store    → dakota-live.iso
+CI (build-iso.yml) — same entry point:
+  └─ sudo just ... iso-sd-boot dakota → container build + VFS store + squashfs + ISO
 ```
 
 ### Container: `<target>-installer` (`live/Containerfile` — 3 stages)
@@ -55,8 +52,7 @@ See `docs/multi-arch.md` for design rationale and size estimates.
 ```
 EFI/efi.img                  — FAT32 ESP: systemd-boot + kernel + initramfs
 EFI/BOOT/BOOTX64.EFI        — EFI fallback (Proxmox OVMF / Ventoy)
-LiveOS/squashfs.img          — squashfs of the full live rootfs (NVIDIA variant)
-LiveOS/store.squashfs.img    — offline OCI image store (dakota + dakota-nvidia, CI builds only)
+LiveOS/squashfs.img          — squashfs of the full live rootfs (NVIDIA variant, with embedded VFS store)
 boot/grub/loopback.cfg       — Ventoy/GRUB loopback metadata
 images/pxeboot/*             — kernel/initramfs copies for loopback ISO boot
 ```
@@ -96,19 +92,26 @@ xorriso -indev output/dakota-live.iso -report_system_area plain 2>/dev/null | gr
 Note: `fdisk -l` shows `Disklabel type: dos` on hybrid layouts — this is expected and
 does NOT mean GPT is missing. `gdisk`, `parted`, and UEFI firmware see GPT correctly.
 
-## Offline image store (`store.squashfs.img`)
+## Offline image store (VFS embedded in main squashfs)
 
-CI builds embed a second squashfs at `LiveOS/store.squashfs.img` containing both
-`dakota` and `dakota-nvidia` images as VFS containers-storage. The installer mounts
-this store for offline installation — no network pull required.
+The OCI image is baked directly into the main `squashfs.img` as VFS containers-storage
+at `/var/lib/containers/storage`. The installer finds it there for offline installation
+without a network pull. No separate `store.squashfs.img` is needed.
 
-`scripts/build-offline-store.sh` creates the store:
-1. Creates an isolated podman graphroot at a temp directory
-2. Runs `skopeo copy` for each image into that graphroot (JSON tar-split format)
-3. Runs `mksquashfs` on the resulting VFS store directory
+`just iso-sd-boot` populates the store via `podman unshare` + `skopeo copy` inside the
+installer container. The two-step skopeo copy (containers-storage → vfs-staging →
+squashfs) ensures tar-split metadata is written in JSON format (the live ISO expects
+JSON; build-host containers-storage emits binary tar-split).
 
-The store is mounted at `/var/lib/containers/storage` at runtime so the installer
-finds the images at the expected path.
+**Why VFS not overlay?**
+- Overlay driver creates a conflicting `db.sql` file at first live boot
+- VFS layers are plain directories — readable without mount privileges
+- `driver = "vfs"` in `/etc/containers/storage.conf` set by `configure-live.sh`
+
+**skopeo /var/tmp sizing:**
+The squashed dakota-nvidia image has a ~9GB uncompressed layer. skopeo writes temp
+blobs to `/var/tmp` directly (ignores `TMPDIR` set by fisherman). Live ISO sets
+`/var/tmp` tmpfs to `size=80%` so it scales with machine RAM (16GB → 13GB available).
 
 ## Embedded OCI image (VFS containers-storage)
 
@@ -215,3 +218,66 @@ for NVIDIA auto-detection to work end-to-end.
 `dakota:stable` is NOT needed in the offline store — it's only a tracking ref fetched
 from GHCR on the first `bootc upgrade`. Storing only `dakota-nvidia:stable` saves
 ~2.2 GB per ISO (~7.8 GB → ~5.6 GB).
+
+### flatpak install --bundle missing deploy/ ref in container builds (2026-06)
+
+`flatpak install --bundle` in a rootless podman container build creates the
+`installer-origin:` remote ref but does NOT create the `deploy/` ostree ref or the
+`active → <hash>` symlink inside the branch dir. `flatpak run` / `flatpak list` require
+both. The system flatpak daemon would normally create these — but it doesn't run inside
+container builds.
+
+**Fix:** Use `ostree init` + `flatpak build-import-bundle` + local `file://` remote +
+`flatpak install` from that remote. Then scan all branch dirs and create
+`active → <hash>` symlinks if missing.
+
+```bash
+INSTALLER_LOCAL_REPO="/tmp/installer-local-repo"
+ostree init --repo="${INSTALLER_LOCAL_REPO}" --mode=archive-z2
+flatpak build-import-bundle "${INSTALLER_LOCAL_REPO}" /tmp/installer.flatpak
+flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"
+flatpak install --system --noninteractive installer-local "${INSTALLER_APP_ID}"
+flatpak remote-delete --system --force installer-local
+
+# Create missing active symlink
+for _branch_dir in /var/lib/flatpak/app/${INSTALLER_APP_ID}/x86_64/*/; do
+    if [[ ! -L "${_branch_dir%/}/active" ]]; then
+        _hash=$(find "${_branch_dir%/}" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -1)
+        [[ -n "${_hash}" ]] && ln -sfn "${_hash}" "${_branch_dir%/}/active"
+    fi
+done
+```
+
+### bluefin-remove-installer.service whiteout files on live ISO (2026-06)
+
+The installed system ships `bluefin-remove-installer.service` which uninstalls the
+installer Flatpak on first boot. On a live ISO, this service runs and tries to
+`flatpak uninstall`, fails with "Invalid cross-device link" (squashfs-backed overlayfs),
+but leaves overlayfs whiteout entries (`c--------- 0,0`) that hide the `active` and
+`current` symlinks — making the installer invisible to `flatpak run`/`flatpak list`.
+
+**Fix:** systemd drop-in `ConditionPathExists=!/etc/bootc-installer/live-iso-mode`.
+`configure-live.sh` touches `/etc/bootc-installer/live-iso-mode` so the service skips
+on live ISOs. On installed systems the file is absent — service runs normally.
+
+Drop-in path: `/etc/systemd/system/bluefin-remove-installer.service.d/live-skip.conf`
+
+```ini
+[Unit]
+ConditionPathExists=!/etc/bootc-installer/live-iso-mode
+```
+
+### LUKS E2E CI build pipeline (2026-06)
+
+`test-luks-install.yml` originally used a 4-step manual pipeline:
+`podman build` + `build-live-squashfs.sh` + `build-offline-store.sh` + `build-iso.sh --store`.
+This was tied to the old superiso/overlay store pattern. After switching to the VFS
+embedded store, use `just iso-sd-boot` directly (same as `build-iso.yml`):
+
+```yaml
+sudo just debug=1 installer_channel=${{ matrix.installer_channel }} \
+  output_dir=/var/iso-build iso-sd-boot dakota
+```
+
+**Dev channel fallback tag:** `tuna-os/tuna-installer` uses tag `continuous-dev` for
+dev rolling releases, NOT `latest-dev`. `projectbluefin/bootc-installer` uses `latest-dev`.

--- a/docs/build.md
+++ b/docs/build.md
@@ -134,6 +134,28 @@ just debug=1 boot-libvirt-debug dakota
 
 ## Lessons
 
+### Unified ISO: one nvidia image for all hardware (2026-06)
+
+Dakota ships a single ISO built from `ghcr.io/projectbluefin/dakota-nvidia:stable`.
+The live environment runs the nvidia image. At install time, `bootc-installer`'s
+`nvidia_imgref` mechanism auto-detects the GPU:
+
+- **NVIDIA GPU present:** installs `dakota-nvidia:stable`, `targetImgref=dakota-nvidia:stable`
+- **No NVIDIA GPU:** installs offline from the nvidia VFS store, `targetImgref=dakota:stable` —
+  first `bootc upgrade` rebases to the correct non-nvidia variant automatically
+
+**Expected ISO size:** ~5.3 GB (with `compression=release`). If the ISO is ~8 GB, the
+offline OCI store was double-embedded — see `ci.md` lessons.
+
+### CI uses `SUPERISO_COMPRESSION=release` (2026-06)
+
+The `build-iso.yml` CI workflow sets `SUPERISO_COMPRESSION=release` in the squashfs build
+step, producing zstd-15 compression. Local `just iso-sd-boot` defaults to `compression=fast`
+(zstd-3). For production ISOs destined for R2, always use release compression:
+```bash
+just compression=release iso-sd-boot dakota
+```
+
 ### `dakota/src/flatpaks` diverged from `live/src/flatpaks` (2026-06)
 
 `dakota/src/flatpaks` contains `be.alexandervanhee.gradia` but `live/src/flatpaks` does not.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,3 +176,31 @@ QEMU serial (`-serial file:...`) captures ttyS0 output only.
 
 Fix: `StandardOutput=tty` + `TTYPath=/dev/ttyS0` for direct serial writes.
 CI falls back to SSH connectivity check if the marker is absent.
+
+### Offline install failed: VFS containers-storage missing from CI ISOs (2026-06)
+
+**Symptom:** `fisherman: fatal: ... reference "containers-storage:ghcr.io/projectbluefin/dakota-nvidia:stable" does not resolve to an image ID`
+
+**Root cause:** The CI build called `scripts/build-live-squashfs.sh` without `--oci-image`, so
+the live squashfs shipped with an empty `/var/lib/containers/storage`.  The live `recipe.json`
+has `local_imgref=containers-storage:ghcr.io/projectbluefin/dakota-nvidia:stable`, which
+fisherman treats as authoritative.  When the local store is empty, the install fails even if
+the user has a working internet connection (fisherman does not fall back to `docker://`).
+
+**Why local builds were unaffected:** `just iso-sd-boot` always did the squash+skopeo step and
+baked the OCI into the squashfs.  CI diverged from this path and the gap was undetected
+because CI only validated boot, not install.
+
+**Fix:** `scripts/build-live-squashfs.sh` now accepts `--oci-image <ref>`.  When provided it:
+1. Squashes the payload to a single layer via `buildah commit --squash`
+2. Runs `skopeo copy` inside the live container (for JSON tar-split compatibility)
+3. Bind-mounts the populated VFS staging dir at `/var/lib/containers/storage` before mksquashfs
+
+`build-iso.yml` now passes `--oci-image ghcr.io/projectbluefin/dakota-nvidia:stable` and
+asserts the embedded store is non-empty before uploading the ISO to R2.
+
+**Invariant:** The CI-built squashfs **must** contain a populated VFS store at
+`var/lib/containers/storage` with the `dakota-nvidia:stable` image.  The assertion step
+catches any regression before upload.
+
+See issue #78.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -23,15 +23,19 @@ How the GitHub Actions workflows build, test, and publish Dakota ISOs.
 1. **Free disk space** — `jlumbroso/free-disk-space` reclaims ~119 GB at `/var/iso-build`
 2. **Install deps** — `apt-get install podman buildah skopeo mtools xorriso squashfs-tools dosfstools isomd5sum`
 3. **Log in to GHCR** — `sudo podman login ghcr.io`
-4. **Pull payload images** — pulls `dakota-nvidia:latest` and `dakota:latest` into local podman store
+4. **Pull payload image** — pulls only `dakota-nvidia:stable` (the unified ISO base)
 5. **Build live container** — `podman build live/ --build-arg TARGET=dakota-nvidia` → `localhost/dakota-nvidia-live:latest`
-6. **Build live squashfs** — `scripts/build-live-squashfs.sh` → `dakota-nvidia.rootfs.sfs` + `dakota-nvidia-boot.tar`
-7. **Build offline store** — `scripts/build-offline-store.sh` → `store.squashfs.img` (both dakota + dakota-nvidia)
-8. **Assemble ISO** — `live/src/build-iso.sh --store store.squashfs.img ...` → `dakota-live.iso` (~4.5 GB)
-9. **Generate checksum** — dated + latest variants
-10. **Upload to R2** — `dakota-live-YYYYMMDD-<sha>.iso` + `dakota-live-latest.iso` + checksums
-11. **Boot verification** — QEMU UEFI boot, wait for `DAKOTA_LIVE_READY` serial marker
-12. **Upload artifacts** — ISO + checksum + screenshot (7-day retention)
+6. **Build live squashfs** — `scripts/build-live-squashfs.sh` with `SUPERISO_COMPRESSION=release` → `dakota-nvidia.rootfs.sfs` + `dakota-nvidia-boot.tar` (~5.3 GB)
+7. **Assemble ISO** — `live/src/build-iso.sh` → `dakota-live.iso` (no `--store` flag — OCI already embedded in squashfs as VFS)
+8. **Generate checksum** — dated + latest variants
+9. **Upload to R2** — `dakota-live-YYYYMMDD-<sha>.iso` + `dakota-live-latest.iso` + checksums
+10. **Boot verification** — QEMU UEFI boot, wait for `DAKOTA_LIVE_READY` serial marker
+11. **Upload artifacts** — ISO + checksum + screenshot (7-day retention)
+
+> ⚠️ **Do not add `--store` back or re-add the offline store squashfs step.**  
+> The OCI image is already embedded in the live squashfs via VFS containers-storage.
+> Building a separate `store.squashfs.img` doubles the OCI payload, producing an ~8 GB
+> ISO instead of ~5.3 GB. See lessons below.
 
 ### ⚠️ installer_channel is locked to `stable` in CI
 
@@ -134,9 +138,26 @@ pip install pytest
 pytest tests/ -v
 ```
 
----
+### Lessons
 
-## Lessons
+### Double-embedded OCI store inflates ISO to 8 GB (2026-06)
+
+The live container (`live/Containerfile`) already bakes the OCI image into the squashfs
+as VFS containers-storage via `configure-live.sh` and `install-flatpaks.sh`.
+Building a separate `store.squashfs.img` with `scripts/build-offline-store.sh` and
+passing `--store store.squashfs.img` to `build-iso.sh` embeds the same ~4 GB OCI
+image **twice** in the final ISO — resulting in ~8 GB instead of ~5.3 GB.
+
+**Fix:** Remove the "Build offline image store squashfs" CI step entirely.
+Call `build-iso.sh` without `--store`. This is the correct architecture for the
+unified VFS-embedded ISO.
+
+### Release compression for production ISOs (2026-06)
+
+`scripts/build-live-squashfs.sh` defaults to zstd level 3 (`SUPERISO_COMPRESSION=fast`).
+CI sets `SUPERISO_COMPRESSION=release` (zstd-15, 1M blocks) in the squashfs build step —
+this produces ~20% smaller ISOs at ~5× longer squashfs build time. Always use `release`
+for ISOs published to R2. Use `fast` only for local testing.
 
 ### installer_channel=dev regression: oci-cache/index.json not found (2026-05)
 

--- a/docs/luks-testing.md
+++ b/docs/luks-testing.md
@@ -147,6 +147,24 @@ graphical console.
 
 ## Lessons
 
+### Boot installed disk: qcow2 + no cdrom = OVMF discovers virtio-blk (2026-06)
+
+When booting the **installed** disk in QEMU, two things are required for OVMF to
+auto-discover and boot from the virtio-blk device without EFI NVRAM entries:
+
+1. **Disk must be qcow2** (not raw). OVMF's fallback boot scan works correctly with
+   qcow2; raw format can cause scan failures depending on OVMF version.
+2. **No cdrom device attached.** When a cdrom is also connected, OVMF tries it first
+   and may fail to enumerate the virtio-blk device for fallback boot.
+
+The `luks-boot-qemu-installed` justfile recipe follows this pattern — no `-device scsi-cd`,
+disk as `format=qcow2`. Always use the justfile recipe for installed-disk boot.
+
+If you installed to a raw image (e.g. via `dd` or a raw-format QEMU disk), convert first:
+```bash
+qemu-img convert -f raw -O qcow2 /var/tmp/install-disk.img /var/tmp/dakota-luks-install.qcow2
+```
+
 ### /var/tmp for disk images, never /tmp (2026-05)
 
 `/tmp` is a 16 GB tmpfs on this host. Two 50 GB sparse qcow2 images fill it

--- a/justfile
+++ b/justfile
@@ -89,12 +89,18 @@ _payload_ref_flag target:
     @if [ -f "{{target}}/payload_ref" ]; then echo "--bootc-installer-payload-ref $(cat '{{target}}/payload_ref' | tr -d '[:space:]')"; fi
 
 container target:
-    @test -f "{{target}}/payload_ref" || { echo "ERROR: {{target}}/payload_ref not found — create it with the base image reference, e.g.: echo 'ghcr.io/projectbluefin/dakota:latest' > {{target}}/payload_ref"; exit 1; }
+    #!/usr/bin/bash
+    test -f "{{target}}/payload_ref" || { echo "ERROR: {{target}}/payload_ref not found — create it with the base image reference, e.g.: echo 'ghcr.io/projectbluefin/dakota:latest' > {{target}}/payload_ref"; exit 1; }
+    # live_target overrides the Containerfile TARGET build-arg when the live
+    # environment image differs from the variant directory name.
+    # e.g. the 'dakota' variant builds its live env from 'dakota-nvidia' so all
+    # hardware can boot live, while payload_ref controls the offline store.
+    LIVE_TARGET=$(cat "{{target}}/live_target" 2>/dev/null | tr -d '[:space:]' || echo "{{target}}")
     podman build --cap-add sys_admin --security-opt label=disable \
         --layers \
         --build-arg DEBUG={{debug}} \
         --build-arg INSTALLER_CHANNEL={{installer_channel}} \
-        --build-arg TARGET={{target}} \
+        --build-arg TARGET="${LIVE_TARGET}" \
         -t {{target}}-installer -f ./live/Containerfile ./live
 
 # Build a systemd-boot UEFI live ISO for the given target.

--- a/live/Containerfile
+++ b/live/Containerfile
@@ -20,7 +20,7 @@
 ARG TARGET=dakota-nvidia
 
 # ── Stage 1: Reference image (kernel modules source) ─────────────────────────
-FROM ghcr.io/projectbluefin/${TARGET}:latest AS ref
+FROM ghcr.io/projectbluefin/${TARGET}:stable AS ref
 
 # ── Stage 2: Debian — builds the dmsquash-live initramfs ─────────────────────
 FROM debian:sid AS initramfs-builder
@@ -44,7 +44,7 @@ RUN set -ex; \
 
 # ── Stage 3: Final live image ─────────────────────────────────────────────────
 ARG TARGET=dakota-nvidia
-FROM ghcr.io/projectbluefin/${TARGET}:latest
+FROM ghcr.io/projectbluefin/${TARGET}:stable
 
 ARG TARGET=dakota-nvidia
 ARG INSTALLER_CHANNEL=stable

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -423,48 +423,22 @@ EOF
 mkdir -p /usr/lib/tmpfiles.d
 echo 'f /etc/hostname 0644 - - - dakota-live' > /usr/lib/tmpfiles.d/live-hostname.conf
 
-# ── containers-storage: overlay + superiso-store ──────────────────────────────
-# The ISO carries both Dakota images in a shared store squashfs
-# (LiveOS/store.squashfs.img) built by tacklebox offline_payloads.
-# dmsquash-live mounts the ISO at /run/initramfs/live, so the squashfs is
-# visible at /run/initramfs/live/LiveOS/store.squashfs.img.
-# We mount it at /var/lib/superiso-store via a systemd mount unit and register
-# it as an additionalimagestores so bootc-installer can install either image
-# without a network pull.
+# ── containers-storage: VFS driver ───────────────────────────────────────────
+# The justfile bakes the OCI image into the main squashfs as VFS containers-
+# storage at /var/lib/containers/storage (skopeo copy via the installer image
+# so tar-split metadata is in JSON format the live ISO expects).
+# Using driver="vfs" lets bootc-installer and fisherman find the embedded image
+# directly without any separate store squashfs or additionalimagestore.
+# (Overlay driver would fail to read VFS-format layers and create a conflicting
+# db.sql file at first boot.)
 
-mkdir -p /var/lib/superiso-store /var/lib/containers/storage
-
-# systemd mount unit — same pattern as superiso Containerfile.generic.
-STORE_UNIT="$(systemd-escape --path /var/lib/superiso-store).mount"
-cat > "/usr/lib/systemd/system/${STORE_UNIT}" << 'STOREUNITEOF'
-[Unit]
-Description=Tacklebox offline image store (loop-mounted from live ISO)
-DefaultDependencies=no
-After=systemd-remount-fs.service local-fs-pre.target
-Before=local-fs.target
-ConditionPathExists=/run/initramfs/live/LiveOS/store.squashfs.img
-
-[Mount]
-What=/run/initramfs/live/LiveOS/store.squashfs.img
-Where=/var/lib/superiso-store
-Type=squashfs
-Options=loop,ro,nodev
-
-[Install]
-WantedBy=local-fs.target
-STOREUNITEOF
-systemctl enable "${STORE_UNIT}"
-
-# overlay driver + additionalimagestores so both Dakota images are resolvable
-# by bootc-installer and fisherman without touching the live writable store.
+mkdir -p /var/lib/containers/storage
 mkdir -p /etc/containers
 cat > /etc/containers/storage.conf << 'STOREOF'
 [storage]
-driver = "overlay"
+driver = "vfs"
 runroot = "/run/containers/storage"
 graphroot = "/var/lib/containers/storage"
-[storage.options]
-additionalimagestores = ["/var/lib/superiso-store"]
 STOREOF
 
 # fisherman handles scratch space, transport-prefix stripping, OCI export, and

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -263,11 +263,21 @@ install -Dm644 "$SCRIPT_DIR/images/dakotaraptor.png" /usr/share/bootc-installer/
 #                 local_imgref for offline installation
 #
 # TARGET controls which OCI image is embedded in this squashfs's VFS
-# containers-storage and therefore available for offline install.  Each live
-# environment on the dual-env ISO carries its own image; the other variant
-# can be installed via network.
+# containers-storage and therefore available for offline install.  The live
+# environment is always the NVIDIA variant (safe for all hardware).
+#
+# imgref is set to the BASE (non-nvidia) image so that bootc-installer's
+# nvidia_imgref auto-detection (processor.py) can match the images.json entry:
+#   - NVIDIA GPU present  → installs dakota-nvidia:stable, tracks dakota-nvidia:stable
+#   - No NVIDIA GPU       → installs from ISO (dakota-nvidia:stable offline),
+#                           but targetImgref = dakota:stable so first bootc upgrade
+#                           rebases to the lighter non-nvidia variant automatically
+#
+# local_imgref overrides the install SOURCE to the offline store image (nvidia),
+# while imgref/targetImgref control what tag is written into the installed system.
 TARGET="${TARGET:-dakota-nvidia}"
-IMGREF="ghcr.io/projectbluefin/${TARGET}:latest"
+BASE_IMGREF="ghcr.io/projectbluefin/dakota:stable"
+NVIDIA_IMGREF="ghcr.io/projectbluefin/dakota-nvidia:stable"
 
 mkdir -p /etc/bootc-installer
 cp "$SCRIPT_DIR/etc/bootc-installer/images.json" /etc/bootc-installer/images.json
@@ -280,8 +290,10 @@ import json, sys
 with open("$SCRIPT_DIR/etc/bootc-installer/recipe.json") as f:
     recipe = json.load(f)
 
-recipe["imgref"] = "$IMGREF"
-recipe["local_imgref"] = "containers-storage:$IMGREF"
+# imgref = base image — matched by _find_nvidia_imgref_for() in processor.py
+# local_imgref = nvidia image — overrides install source to offline store
+recipe["imgref"] = "$BASE_IMGREF"
+recipe["local_imgref"] = "containers-storage:$NVIDIA_IMGREF"
 
 with open("/etc/bootc-installer/recipe.json", "w") as f:
     json.dump(recipe, f, indent=2)

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -424,13 +424,14 @@ mkdir -p /usr/lib/tmpfiles.d
 echo 'f /etc/hostname 0644 - - - dakota-live' > /usr/lib/tmpfiles.d/live-hostname.conf
 
 # ── containers-storage: VFS driver ───────────────────────────────────────────
-# The justfile bakes the OCI image into the main squashfs as VFS containers-
-# storage at /var/lib/containers/storage (skopeo copy via the installer image
-# so tar-split metadata is in JSON format the live ISO expects).
-# Using driver="vfs" lets bootc-installer and fisherman find the embedded image
-# directly without any separate store squashfs or additionalimagestore.
+# The OCI payload image is baked into the squashfs as VFS containers-storage
+# at /var/lib/containers/storage.  For CI builds, scripts/build-live-squashfs.sh
+# does this via --oci-image (squash → skopeo copy inside the installer container).
+# For local builds, the justfile iso-sd-boot recipe does the same.
+# Using driver="vfs" lets fisherman find the embedded image via
+# local_imgref="containers-storage:<ref>" in recipe.json for offline install.
 # (Overlay driver would fail to read VFS-format layers and create a conflicting
-# db.sql file at first boot.)
+# db.sql at first boot.)
 
 mkdir -p /var/lib/containers/storage
 mkdir -p /etc/containers

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -195,11 +195,11 @@ AutomaticLogin=liveuser
 GDMEOF
 
 # ── /var/tmp tmpfs ────────────────────────────────────────────────────────────
-# The live overlayfs puts /var on a small RAM overlay.  bootc needs substantial
-# space in /var/tmp when staging an install; mount a dedicated tmpfs there.
-# Using size=8G instead of size=50%: on VMs with less RAM the kernel silently
-# caps to available memory, but this avoids the 2 GiB ceiling that a 4 GiB VM
-# gets with 50%.  On real hardware with 16+ GiB RAM it's a non-issue.
+# The live overlayfs puts /var on a small RAM overlay.  During install skopeo
+# writes intermediate blob temp files to /var/tmp regardless of TMPDIR.  With
+# the squashed 9 GB dakota-nvidia image the uncompressed blob exceeds 8 GB, so
+# use 80% of total RAM so it scales with the machine (min system requirement
+# for the nvidia image is 16 GB, giving ~13 GB here).
 cat > /usr/lib/systemd/system/var-tmp.mount << 'UNITEOF'
 [Unit]
 Description=Large tmpfs for /var/tmp in the live environment
@@ -208,7 +208,7 @@ Description=Large tmpfs for /var/tmp in the live environment
 What=tmpfs
 Where=/var/tmp
 Type=tmpfs
-Options=size=8G,nr_inodes=1m
+Options=size=80%,nr_inodes=1m
 
 [Install]
 WantedBy=local-fs.target

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -117,21 +117,27 @@ chown -R liveuser:liveuser /home/liveuser/.config
 # the welcome-dialog-last-shown-version=999 key below.
 rm -f /usr/share/applications/org.gnome.Tour.desktop
 
-# Override the tuna-installer flatpak's desktop entry so it appears as
-# "Dakota Installer" with the dakota icon instead of "bootc Installer (Devel)".
+# App ID differs between stable and dev channel builds.  Define early so it
+# can be used in the desktop override and autostart sections below.
+INSTALLER_APP_ID="org.bootcinstaller.Installer"
+[[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
+
+# Override the installer flatpak's desktop entry so it appears as
+# "Dakota Installer" with the dakota icon instead of "bootc Installer".
 # /usr/local/share/applications/ is earlier in XDG_DATA_DIRS than the flatpak
 # export path, so this file takes precedence without modifying the flatpak.
 mkdir -p /usr/local/share/applications
-cat > /usr/local/share/applications/org.bootcinstaller.Installer.Devel.desktop << 'DESKTOPEOF'
+INSTALLER_DESKTOP_ID="${INSTALLER_APP_ID}.desktop"
+cat > "/usr/local/share/applications/${INSTALLER_DESKTOP_ID}" << DESKTOPEOF
 [Desktop Entry]
 Name=Dakota Installer
-Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=bootc-installer org.bootcinstaller.Installer.Devel
+Exec=/usr/bin/flatpak run --branch=master --arch=x86_64 --command=bootc-installer ${INSTALLER_APP_ID}
 Icon=dakota
 Terminal=false
 Type=Application
 Categories=GTK;System;Settings;
 StartupNotify=true
-X-Flatpak=org.bootcinstaller.Installer.Devel
+X-Flatpak=${INSTALLER_APP_ID}
 DESKTOPEOF
 
 # Suppress the GNOME Tour / "Welcome to Bluefin" dialog on first login.
@@ -304,10 +310,19 @@ PYEOF
 # inside a Flatpak sandbox.
 touch /etc/bootc-installer/live-iso-mode
 
+# Prevent bluefin-remove-installer.service from running in the live env.
+# The service is designed for installed systems to remove the installer on first
+# boot.  In the live ISO the installer must remain available.  The condition
+# ConditionPathExists=!/etc/bootc-installer/live-iso-mode ensures:
+#   live ISO  → live-iso-mode EXISTS  → service is skipped ✓
+#   installed → live-iso-mode ABSENT  → service runs normally ✓
+mkdir -p /usr/lib/systemd/system/bluefin-remove-installer.service.d
+cat > /usr/lib/systemd/system/bluefin-remove-installer.service.d/live-skip.conf << 'SKIPCEOF'
+[Unit]
+ConditionPathExists=!/etc/bootc-installer/live-iso-mode
+SKIPCEOF
+
 # ── Installer autostart ───────────────────────────────────────────────────────
-# App ID differs between stable and dev channel builds.
-INSTALLER_APP_ID="org.bootcinstaller.Installer"
-[[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
 
 mkdir -p /etc/xdg/autostart
 # BOOTC_CUSTOM_RECIPE (bootc-installer): inside the Flatpak sandbox /etc is

--- a/live/src/configure-live.sh
+++ b/live/src/configure-live.sh
@@ -310,13 +310,13 @@ INSTALLER_APP_ID="org.bootcinstaller.Installer"
 [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
 
 mkdir -p /etc/xdg/autostart
-# VANILLA_CUSTOM_RECIPE workaround (tuna-os/tuna-installer#26): inside the
-# Flatpak sandbox /etc is reserved; the host /etc is at /run/host/etc.  Pass
-# the recipe via env var at the /run/host path so the installer finds it.
+# BOOTC_CUSTOM_RECIPE (bootc-installer): inside the Flatpak sandbox /etc is
+# reserved; the host /etc is at /run/host/etc.  Pass the recipe via env var
+# at the /run/host path so the installer finds it.
 cat > /etc/xdg/autostart/tuna-installer.desktop << DTEOF
 [Desktop Entry]
 Name=Dakota Installer
-Exec=flatpak run --env=VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
+Exec=flatpak run --env=BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
 Icon=dakota
 Type=Application
 X-GNOME-Autostart-enabled=true
@@ -330,7 +330,7 @@ cat > /usr/share/applications/dakota-installer.desktop << DTEOF
 [Desktop Entry]
 Name=Dakota Installer
 Comment=Install Dakota to your computer
-Exec=flatpak run --env=VANILLA_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
+Exec=flatpak run --env=BOOTC_CUSTOM_RECIPE=/run/host/etc/bootc-installer/recipe.json ${INSTALLER_APP_ID}
 Icon=dakota
 Type=Application
 Categories=System;

--- a/live/src/etc/bootc-installer/images.json
+++ b/live/src/etc/bootc-installer/images.json
@@ -1,21 +1,11 @@
 {
-  "default_image": "ghcr.io/projectbluefin/dakota-nvidia:latest",
+  "default_image": "ghcr.io/projectbluefin/dakota:stable",
   "fallback_flatpaks": [],
   "images": [
     {
-      "name": "Dakota (NVIDIA)",
-      "imgref": "ghcr.io/projectbluefin/dakota-nvidia:latest",
-      "desc": "Project Bluefin Prototype — NVIDIA GPU support",
-      "icon": "resource:///org/bootcinstaller/Installer/images/dakota.png",
-      "bootloader": "systemd",
-      "filesystem": "btrfs",
-      "composefs": true,
-      "needs_user_creation": false,
-      "flatpak_var_path": "state/os/default/var"
-    },
-    {
       "name": "Dakota",
-      "imgref": "ghcr.io/projectbluefin/dakota:latest",
+      "imgref": "ghcr.io/projectbluefin/dakota:stable",
+      "nvidia_imgref": "ghcr.io/projectbluefin/dakota-nvidia:stable",
       "desc": "Project Bluefin Prototype",
       "icon": "resource:///org/bootcinstaller/Installer/images/dakota.png",
       "bootloader": "systemd",

--- a/live/src/etc/bootc-installer/recipe.json
+++ b/live/src/etc/bootc-installer/recipe.json
@@ -2,8 +2,8 @@
   "log_file": "/var/log/bootc-installer.log",
   "distro_name": "Dakota",
   "distro_logo": "resource:///org/bootcinstaller/Installer/images/dakota.png",
-  "imgref": "ghcr.io/projectbluefin/dakota:latest",
-  "local_imgref": "containers-storage:ghcr.io/projectbluefin/dakota:latest",
+  "imgref": "ghcr.io/projectbluefin/dakota:stable",
+  "local_imgref": "containers-storage:ghcr.io/projectbluefin/dakota-nvidia:stable",
   "bootloader": "systemd",
   "composeFsBackend": true,
   "tour": {

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -73,6 +73,7 @@ INSTALLER_APP_ID="org.bootcinstaller.Installer"
 # file:// remote goes through the full deploy pipeline and correctly creates
 # the deploy/ ref so the app is visible and runnable.
 INSTALLER_LOCAL_REPO="/tmp/installer-local-repo"
+ostree init --repo="${INSTALLER_LOCAL_REPO}" --mode=archive-z2
 flatpak build-import-bundle "${INSTALLER_LOCAL_REPO}" /tmp/tuna-installer.flatpak
 rm -f /tmp/tuna-installer.flatpak
 flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -68,7 +68,6 @@ INSTALLER_APP_ID="org.bootcinstaller.Installer"
 
 flatpak install --system --noninteractive --bundle /tmp/tuna-installer.flatpak || \
     flatpak update --system --noninteractive "${INSTALLER_APP_ID}"
-rm /tmp/tuna-installer.flatpak
 
 # flatpak install --bundle in a container build (no flatpak daemon) does not
 # create the 'current' symlink that flatpak run requires to find the deployment.
@@ -83,7 +82,7 @@ for BRANCH_DIR in "${APP_ARCH_DIR}"/*/; do
         echo "Created flatpak current symlink: ${BRANCH}/${DEPLOY}"
     fi
 done
-rm /tmp/tuna-installer.flatpak
+rm -f /tmp/tuna-installer.flatpak
 
 flatpak override --system --filesystem=/etc:ro "${INSTALLER_APP_ID}"
 

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -45,10 +45,11 @@ INSTALLER_REPO="projectbluefin/bootc-installer"
 FALLBACK_REPO="tuna-os/tuna-installer"
 FLATPAK_FILENAME="org.bootcinstaller.Installer.flatpak"
 if [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]]; then
-    RELEASE_TAG="latest-dev"
     FLATPAK_FILENAME="org.bootcinstaller.Installer.Devel.flatpak"
-    PRIMARY_URL="https://github.com/${INSTALLER_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"
-    FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"
+    # projectbluefin/bootc-installer uses tag "latest-dev" for dev builds.
+    # tuna-os/tuna-installer uses tag "continuous-dev" — different naming convention.
+    PRIMARY_URL="https://github.com/${INSTALLER_REPO}/releases/download/latest-dev/${FLATPAK_FILENAME}"
+    FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/continuous-dev/${FLATPAK_FILENAME}"
 else
     # Use GitHub's /releases/latest/download/ redirect — always resolves to the
     # current latest stable release without needing to know the version tag.

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -66,23 +66,20 @@ fi
 INSTALLER_APP_ID="org.bootcinstaller.Installer"
 [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]] && INSTALLER_APP_ID="org.bootcinstaller.Installer.Devel"
 
-flatpak install --system --noninteractive --bundle /tmp/tuna-installer.flatpak || \
-    flatpak update --system --noninteractive "${INSTALLER_APP_ID}"
-
-# flatpak install --bundle in a container build (no flatpak daemon) does not
-# create the 'current' symlink that flatpak run requires to find the deployment.
-# Create it manually so the installer launches correctly in the live environment.
-APP_ARCH_DIR="/var/lib/flatpak/app/${INSTALLER_APP_ID}/x86_64"
-for BRANCH_DIR in "${APP_ARCH_DIR}"/*/; do
-    BRANCH=$(basename "${BRANCH_DIR}")
-    [[ "$BRANCH" == "current" ]] && continue
-    DEPLOY=$(ls "${BRANCH_DIR}" 2>/dev/null | head -1)
-    if [[ -n "$DEPLOY" ]] && [[ ! -L "${APP_ARCH_DIR}/current" ]]; then
-        ln -sfn "${BRANCH}/${DEPLOY}" "${APP_ARCH_DIR}/current"
-        echo "Created flatpak current symlink: ${BRANCH}/${DEPLOY}"
-    fi
-done
+# Import the bundle into a temporary local repo and install from there.
+# flatpak install --bundle in a container build (no running flatpak system
+# daemon) only creates the installer-origin: remote ref — it does NOT create
+# the deploy/ ref that flatpak run/list require.  Installing from a local
+# file:// remote goes through the full deploy pipeline and correctly creates
+# the deploy/ ref so the app is visible and runnable.
+INSTALLER_LOCAL_REPO="/tmp/installer-local-repo"
+flatpak build-import-bundle "${INSTALLER_LOCAL_REPO}" /tmp/tuna-installer.flatpak
 rm -f /tmp/tuna-installer.flatpak
+flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"
+flatpak install --system --noninteractive installer-local "${INSTALLER_APP_ID}" || \
+    flatpak update --system --noninteractive "${INSTALLER_APP_ID}"
+flatpak remote-delete --system installer-local || true
+rm -rf "${INSTALLER_LOCAL_REPO}"
 
 flatpak override --system --filesystem=/etc:ro "${INSTALLER_APP_ID}"
 

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -70,6 +70,21 @@ flatpak install --system --noninteractive --bundle /tmp/tuna-installer.flatpak |
     flatpak update --system --noninteractive "${INSTALLER_APP_ID}"
 rm /tmp/tuna-installer.flatpak
 
+# flatpak install --bundle in a container build (no flatpak daemon) does not
+# create the 'current' symlink that flatpak run requires to find the deployment.
+# Create it manually so the installer launches correctly in the live environment.
+APP_ARCH_DIR="/var/lib/flatpak/app/${INSTALLER_APP_ID}/x86_64"
+for BRANCH_DIR in "${APP_ARCH_DIR}"/*/; do
+    BRANCH=$(basename "${BRANCH_DIR}")
+    [[ "$BRANCH" == "current" ]] && continue
+    DEPLOY=$(ls "${BRANCH_DIR}" 2>/dev/null | head -1)
+    if [[ -n "$DEPLOY" ]] && [[ ! -L "${APP_ARCH_DIR}/current" ]]; then
+        ln -sfn "${BRANCH}/${DEPLOY}" "${APP_ARCH_DIR}/current"
+        echo "Created flatpak current symlink: ${BRANCH}/${DEPLOY}"
+    fi
+done
+rm /tmp/tuna-installer.flatpak
+
 flatpak override --system --filesystem=/etc:ro "${INSTALLER_APP_ID}"
 
 # ── Reconcile Flathub apps against the wanted list ───────────────────────────

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -79,8 +79,26 @@ rm -f /tmp/tuna-installer.flatpak
 flatpak remote-add --system --no-gpg-verify installer-local "file://${INSTALLER_LOCAL_REPO}"
 flatpak install --system --noninteractive installer-local "${INSTALLER_APP_ID}" || \
     flatpak update --system --noninteractive "${INSTALLER_APP_ID}"
-flatpak remote-delete --system installer-local || true
+flatpak remote-delete --system --force installer-local || true
 rm -rf "${INSTALLER_LOCAL_REPO}"
+
+# flatpak install inside a container build (no flatpak-system-helper daemon)
+# creates the deployment directory but omits the 'active' symlink inside the
+# branch directory, leaving the app unreachable to 'flatpak run'/'flatpak list'.
+# Reproduce the symlink that a normal installation would create.
+_app_arch_dir="/var/lib/flatpak/app/${INSTALLER_APP_ID}/x86_64"
+for _branch_dir in "${_app_arch_dir}"/*/; do
+    _branch_dir="${_branch_dir%/}"
+    [[ -d "${_branch_dir}" ]] || continue
+    if [[ ! -L "${_branch_dir}/active" ]]; then
+        # Find the single deployment hash directory
+        _hash=$(find "${_branch_dir}" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | head -1)
+        if [[ -n "${_hash}" ]]; then
+            ln -sfn "${_hash}" "${_branch_dir}/active"
+            echo "Created active symlink: ${_branch_dir}/active → ${_hash}"
+        fi
+    fi
+done
 
 flatpak override --system --filesystem=/etc:ro "${INSTALLER_APP_ID}"
 

--- a/live/src/install-flatpaks.sh
+++ b/live/src/install-flatpaks.sh
@@ -35,26 +35,32 @@ flatpak remote-add --system --if-not-exists flathub \
     https://dl.flathub.org/repo/flathub.flatpakrepo
 
 # bootc-installer bundle
-# INSTALLER_CHANNEL controls which release tag to pull from:
-#   stable (default) → latest-stable (latest stable build from prod branch)
-#   dev              → latest-dev (latest dev build, tracks dev branch)
+# INSTALLER_CHANNEL controls which release to pull from:
+#   stable (default) → GitHub "latest" release (non-pre-release)
+#   dev              → latest-dev rolling pre-release (tracks dev branch)
 # Primary source: projectbluefin/bootc-installer (Project Bluefin's fork).
 # Fallback: tuna-os/tuna-installer (upstream) if projectbluefin assets are unavailable.
-# v2.5.0 includes fisherman v0.2.0 with fix for #38 (OCI cache mount on composefs/btrfs).
+# v2.6.1 adds nvidia_imgref GPU auto-detection support.
 INSTALLER_REPO="projectbluefin/bootc-installer"
 FALLBACK_REPO="tuna-os/tuna-installer"
-RELEASE_TAG="latest-stable"
 FLATPAK_FILENAME="org.bootcinstaller.Installer.flatpak"
 if [[ "${INSTALLER_CHANNEL:-stable}" == "dev" ]]; then
     RELEASE_TAG="latest-dev"
     FLATPAK_FILENAME="org.bootcinstaller.Installer.Devel.flatpak"
+    PRIMARY_URL="https://github.com/${INSTALLER_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"
+    FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}"
+else
+    # Use GitHub's /releases/latest/download/ redirect — always resolves to the
+    # current latest stable release without needing to know the version tag.
+    PRIMARY_URL="https://github.com/${INSTALLER_REPO}/releases/latest/download/${FLATPAK_FILENAME}"
+    FALLBACK_URL="https://github.com/${FALLBACK_REPO}/releases/latest/download/${FLATPAK_FILENAME}"
 fi
 if ! curl --retry 3 --fail --location \
-    "https://github.com/${INSTALLER_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}" \
+    "${PRIMARY_URL}" \
     -o /tmp/tuna-installer.flatpak 2>/dev/null; then
     echo "Primary source unavailable, falling back to ${FALLBACK_REPO}..."
     curl --retry 3 --fail --location \
-        "https://github.com/${FALLBACK_REPO}/releases/download/${RELEASE_TAG}/${FLATPAK_FILENAME}" \
+        "${FALLBACK_URL}" \
         -o /tmp/tuna-installer.flatpak
 fi
 INSTALLER_APP_ID="org.bootcinstaller.Installer"

--- a/scripts/build-live-squashfs.sh
+++ b/scripts/build-live-squashfs.sh
@@ -1,25 +1,41 @@
 #!/usr/bin/bash
-# build-live-squashfs.sh <image> <output-squashfs> <output-boot-tar>
+# build-live-squashfs.sh [--oci-image <ref>] <image> <output-squashfs> <output-boot-tar>
 #
 # Exports a container image as a squashfs suitable for dmsquash-live boot,
 # and a companion tar of the boot files (kernel, initramfs, EFI binary) needed
 # to assemble the ISO ESP.
 #
-# The squashfs contains the full live rootfs.  OCI images for offline
-# installation are NOT embedded here — they live in a separate store squashfs
-# (see build-offline-store.sh) mounted at /var/lib/superiso-store.
+# When --oci-image is given, the referenced OCI image is squashed to a single
+# layer and imported into a VFS containers-storage tree at
+# /var/lib/containers/storage inside the squashfs.  This is the offline install
+# store: at boot, fisherman reads local_imgref=containers-storage:<ref> from
+# recipe.json and finds the image there without a network pull.
+#
+# The OCI image must already be present in the local podman/buildah store.
+# skopeo runs inside the live container so the tar-split metadata is written
+# in the JSON format that the live VFS storage driver expects (not the binary
+# format that the build-host containers/storage might emit).
 #
 # This is the plain-bash equivalent of tacklebox's runEnv() + squashfs stage.
 #
 # Usage (must run as root or with sudo):
 #   sudo bash scripts/build-live-squashfs.sh \
+#       [--oci-image ghcr.io/projectbluefin/dakota-nvidia:stable] \
 #       localhost/dakota-nvidia-live:latest \
 #       /out/dakota-nvidia.rootfs.sfs \
 #       /out/dakota-nvidia-boot.tar
 
 set -euo pipefail
 
-IMAGE="${1:?Usage: build-live-squashfs.sh <image> <output-squashfs> <output-boot-tar>}"
+OCI_IMAGE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --oci-image) OCI_IMAGE="${2:?--oci-image requires an image ref}"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+IMAGE="${1:?Usage: build-live-squashfs.sh [--oci-image <ref>] <image> <output-squashfs> <output-boot-tar>}"
 OUTPUT_SFS="${2:?}"
 OUTPUT_BOOT_TAR="${3:?}"
 
@@ -54,6 +70,58 @@ if [[ "${FS_TYPE}" == "xfs" || "${FS_TYPE}" == "ext4" ]]; then
     fi
 else
     cp -a "${MOUNT}/." "${SFS_ROOT}/"
+fi
+
+# ── Embed offline OCI store (VFS) ─────────────────────────────────────────────
+# When --oci-image is given, squash the payload to a single layer and import it
+# into VFS containers-storage at /var/lib/containers/storage inside the squashfs
+# root.  At boot, fisherman reads local_imgref=containers-storage:<ref> from
+# recipe.json and finds the image there for an offline install.
+if [[ -n "${OCI_IMAGE}" ]]; then
+    echo ">>> [live-squashfs] embedding OCI image ${OCI_IMAGE} into VFS store ..."
+
+    OCI_ARCHIVE="${WORK}/payload.oci.tar"
+    CS_STAGING="${WORK}/vfs-storage"
+    STORAGE_CONF="${WORK}/st.conf"
+
+    mkdir -p "${CS_STAGING}"
+
+    # Chunkified Dakota images have ~120 layers; VFS copies the full filesystem
+    # at each layer.  Squash to 1 layer to keep the store to ~6 GB.
+    echo ">>> [live-squashfs] squashing ${OCI_IMAGE} to single layer ..."
+    SQUASH_CTR="$(buildah from --pull-never "${OCI_IMAGE}")"
+    buildah commit --squash "${SQUASH_CTR}" "oci-archive:${OCI_ARCHIVE}:${OCI_IMAGE}"
+    buildah rm "${SQUASH_CTR}"
+
+    # Write a storage conf for skopeo that uses the staging dir as graphroot.
+    # Paths are container-relative: /vfs-storage is bind-mounted to CS_STAGING.
+    printf '[storage]\ndriver = "vfs"\nrunroot = "/tmp/cs-runroot"\ngraphroot = "/vfs-storage"\n' \
+        > "${STORAGE_CONF}"
+
+    # Run skopeo inside the live container so the VFS tar-split metadata is
+    # written in the JSON format the live ISO expects (build-host containers/
+    # storage may emit a binary format that the live VFS driver cannot read).
+    echo ">>> [live-squashfs] importing squashed OCI into VFS staging dir ..."
+    podman run --rm \
+        --privileged \
+        -v "${OCI_ARCHIVE}:/payload.oci.tar:ro" \
+        -v "${CS_STAGING}:/vfs-storage" \
+        -v "${STORAGE_CONF}:/tmp/st.conf:ro" \
+        "${IMAGE}" \
+        sh -c "mkdir -p /tmp/cs-runroot /var/tmp && \
+               CONTAINERS_STORAGE_CONF=/tmp/st.conf \
+               skopeo copy \
+               oci-archive:/payload.oci.tar:${OCI_IMAGE} \
+               containers-storage:${OCI_IMAGE}"
+
+    rm -f "${OCI_ARCHIVE}" "${STORAGE_CONF}"
+
+    # Bind-mount the populated VFS staging dir at the squashfs root so
+    # mksquashfs captures it at /var/lib/containers/storage.
+    # (The trap already unmounts ${WORK}/squashfs-root/var/lib/containers/storage.)
+    mkdir -p "${SFS_ROOT}/var/lib/containers/storage"
+    mount --bind "${CS_STAGING}" "${SFS_ROOT}/var/lib/containers/storage"
+    echo ">>> [live-squashfs] VFS store size: $(du -sh "${CS_STAGING}" | cut -f1)"
 fi
 
 SFS_LEVEL=3; SFS_BLOCK=131072

--- a/scripts/build-offline-store.sh
+++ b/scripts/build-offline-store.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/bash
+# build-offline-store.sh — DEPRECATED
+#
+# This script is no longer part of the standard ISO build pipeline.  The offline
+# OCI store is now embedded directly into the live squashfs using the --oci-image
+# flag of scripts/build-live-squashfs.sh.  That approach uses VFS containers-
+# storage baked into /var/lib/containers/storage inside the squashfs, which is
+# compatible with the live storage.conf (driver = "vfs") and is simpler to
+# maintain.
+#
+# The superiso-store architecture described here (separate overlay-driver store
+# squashfs, loop-mounted at /var/lib/superiso-store, registered as
+# additionalimagestores) was never fully wired into CI and has an inherent
+# VFS/overlay driver incompatibility with the primary store.  It is retained
+# here for reference only and should not be used.
+#
+# Original description:
 # build-offline-store.sh <output-squashfs> <image> [<image> ...]
 #
 # Pulls each listed OCI image into an isolated containers-storage overlay


### PR DESCRIPTION
## Alpha 3 — Dakota `:stable` with nvidia_imgref auto-detection

Switches the ISO to `ghcr.io/projectbluefin/dakota-nvidia:stable` as the live environment and OCI offline store. At install time, `bootc-installer`'s `nvidia_imgref` mechanism auto-selects between `dakota:stable` (non-NVIDIA) and `dakota-nvidia:stable` (NVIDIA) based on detected hardware.

### How it works
- Single ISO ships `dakota-nvidia:stable` embedded as VFS containers-storage
- `images.json` declares: `imgref=dakota:stable`, `nvidia_imgref=dakota-nvidia:stable`
- `recipe.imgref=dakota:stable` triggers GPU detection in processor.py v2.6.1
- No NVIDIA GPU → installs from nvidia store offline, `targetImgref=dakota:stable` → first `bootc upgrade` rebases to non-nvidia
- NVIDIA GPU → installs `dakota-nvidia:stable` directly

### Local VM install test — PASSED ✅
Full QEMU install test with build 11 ISO:
- GUI installer launched automatically (bluefin-remove-installer correctly skipped)
- fisherman ran: `bootc install to-filesystem --target-imgref ghcr.io/projectbluefin/dakota:stable`
- Source: `oci:/run/fisherman/oci-cache` — fully offline, no network download
- Flatpaks copied: org.gnome.TextEditor + org.mozilla.firefox
- `Installation complete!` at 21:57:13Z
- Installed disk: valid GPT + EFI System Partition + systemd-boot entry `bootc_bluefin_dakota-20260608-1.conf`

### Bugs fixed during local testing

**1. flatpak install --bundle missing deploy/ ref**
`flatpak install --bundle` in a container build creates the installer-origin remote ref but NOT the `deploy/` ref or `active` symlink. Fixed with: `ostree init` + `flatpak build-import-bundle` + local `file://` remote + `flatpak install` + manual `active → <hash>` symlink loop.

**2. bluefin-remove-installer.service whiteout files**
Service tries to `flatpak uninstall` on first live boot, fails with "Invalid cross-device link" on squashfs-backed overlayfs, leaving overlayfs whiteout entries that hide the `active` and `current` symlinks. Fixed with systemd drop-in `ConditionPathExists=!/etc/bootc-installer/live-iso-mode`.

**3. VFS storage driver mismatch**
configure-live.sh was using `driver = "overlay"` + `additionalimagestores` (superiso pattern). But the VFS images baked into the main squashfs need `driver = "vfs"`. Fixed: removed superiso-store.mount unit, switched to `driver = "vfs"`.

**4. skopeo /var/tmp overflow**
The squashed dakota-nvidia image has a ~9GB uncompressed layer; hardcoded `size=8G` tmpfs overflowed. Fixed: `size=80%` scales with RAM (16GB host → 13GB).

**5. VANILLA_CUSTOM_RECIPE → BOOTC_CUSTOM_RECIPE**
configure-live.sh had the tuna-installer env var. projectbluefin/bootc-installer uses `BOOTC_CUSTOM_RECIPE`. Recipe was being silently ignored.

**6. LUKS E2E CI uses old superiso pipeline**
`test-luks-install.yml` used `build-offline-store.sh` (superiso/overlay, removed) with `:latest` image ref. Updated to use `just iso-sd-boot` (VFS pattern). Also fixed `install-flatpaks.sh` dev fallback: tuna-installer uses `continuous-dev` tag, not `latest-dev`.

### Verification evidence
- Local QEMU install test: `Installation complete!` confirmed in fisherman log
- `--target-imgref ghcr.io/projectbluefin/dakota:stable` confirmed in fisherman command
- CI lint/unit tests: ✅ passing
- CI `build-iso.yml` triggered on this branch (run #27170327157)

---
- [ ] CI build-iso.yml passes and uploads to R2
- [ ] Promote R2 dated ISO → `dakota-live-alpha3.iso`
- [ ] Merge PR (human approval required)
- [x] I am using an agent and I take responsibility for this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified NVIDIA-capable ISO that auto-selects appropriate variant at install.

* **Improvements**
  * Switch to stable container images for reproducible builds.
  * Embedded OCI payloads into the main live squashfs, reducing duplicate store artifacts and ISO size.
  * Live build recipe selection made more flexible; tmpfs sizing adjusted for installer operations.
  * Installer download flow now uses primary/fallback URLs.

* **Bug Fixes**
  * Restored Flatpak installer deployment behavior by recreating missing active symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->