### PR TITLE
docs(security): redact R2 credentials from rclone config example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@
 > contribute safely and work in this repository. Human contributors follow the same steps.
 > See the [org-wide agentic model](https://github.com/projectbluefin/common/blob/main/docs/factory/agentic-model.md) for cross-repo rules.
 
-**dakota-iso** builds bootable UEFI live ISOs from [Dakota](https://github.com/projectbluefin/dakota)
-images (GNOME OS / bootc / composefs). Two variants: `dakota` and `dakota-nvidia`.
+**dakota-iso** builds a single bootable UEFI live ISO from [Dakota](https://github.com/projectbluefin/dakota)
+images (GNOME OS / bootc / composefs). The live environment runs the NVIDIA variant; the offline
+embedded OCI store lets the installer deploy to non-NVIDIA hardware without a network pull.
 
 Home repo: [projectbluefin/dakota-iso](https://github.com/projectbluefin/dakota-iso)
 

--- a/README.md
+++ b/README.md
@@ -8,24 +8,28 @@
 
 Builds a bootable UEFI live ISO from [Dakota](https://github.com/projectbluefin/dakota) images — GNOME OS-based workstations using composefs and systemd-boot. The live environment boots straight to GDM with a full GNOME session and launches the Dakota installer automatically.
 
-The ISO is unified: it boots the **NVIDIA** variant live (for systems with NVIDIA GPUs) and ships the standard Dakota image in an offline store so it can be installed on non-NVIDIA hardware without a network pull.
+The ISO boots the **NVIDIA** variant live and embeds the OCI image in a VFS containers-storage
+store inside the squashfs so Dakota can be installed on any hardware without a network pull.
 
 ## How it works
 
 The build uses three steps:
 
-1. **`live/Containerfile`** — a 3-stage multi-arch build that pulls the Dakota NVIDIA image, creates a live user, configures GDM autologin, installs Flatpaks from Flathub, and drops in the installer config.
-2. **`scripts/build-live-squashfs.sh`** — mounts the live container image via `podman image mount` and runs `mksquashfs` directly on the merged overlay view. No per-layer VFS expansion needed.
-3. **`scripts/build-offline-store.sh`** — uses `skopeo copy` to import both `dakota` and `dakota-nvidia` images into an isolated VFS store, then creates a second squashfs that ships inside the ISO for offline installation.
-4. **`live/src/build-iso.sh`** — assembles the final ISO with the live squashfs, boot files, and offline store embedded at `LiveOS/store.squashfs.img`.
+1. **`live/Containerfile`** — a 3-stage build that pulls the Dakota NVIDIA image, creates a live
+   user, configures GDM autologin, installs Flatpaks from Flathub, and drops in the installer config.
+2. **`scripts/build-live-squashfs.sh`** — squashes the payload image to one layer, imports it into
+   a VFS containers-storage tree inside the squashfs root, then calls `mksquashfs`. The OCI store
+   travels inside the squashfs — no separate `store.squashfs.img`.
+3. **`live/src/build-iso.sh`** — assembles the final ISO with the live squashfs and boot files.
 
 The ISO layout:
 - **EFI/efi.img** — FAT32 ESP with systemd-boot, kernel, and initramfs
-- **LiveOS/squashfs.img** — squashfs of the full live rootfs (NVIDIA variant)
-- **LiveOS/store.squashfs.img** — offline OCI image store (both dakota and dakota-nvidia)
+- **LiveOS/squashfs.img** — squashfs of the full live rootfs (NVIDIA variant) + embedded VFS OCI store
 - **El Torito** UEFI entry (no-emulation mode) pointing to the ESP image
 
-At boot, `dmsquash-live` mounts the squashfs and creates an overlayfs so the live environment is fully writable. The offline store is mounted at `/var/lib/containers/storage` so the installer can install Dakota without a network pull.
+At boot, `dmsquash-live` mounts the squashfs and creates an overlayfs so the live environment is
+fully writable. The embedded VFS store at `/var/lib/containers/storage` lets the installer deploy
+Dakota without a network pull.
 
 ## Requirements
 
@@ -39,8 +43,9 @@ At boot, `dmsquash-live` mounts the squashfs and creates an overlayfs so the liv
 | OVMF firmware | `edk2-ovmf` (Fedora/RHEL) or `ovmf` (Debian/Ubuntu) — amd64 |
 
 **Disk space:** The build needs ~22 GB free:
-- ~6 GB for the live squashfs (NVIDIA variant)
-- ~6 GB for the offline store squashfs (both dakota and dakota-nvidia)
+- ~4 GB for the squashed OCI image
+- ~6 GB for the VFS import (single layer)
+- ~6 GB for the squashfs staging tree
 - ~5 GB for the final ISO
 
 By default, output goes to `./output/`. If `/tmp` is a small tmpfs on your machine, override with `just output_dir=/path/with/space iso-sd-boot dakota`.
@@ -52,11 +57,8 @@ By default, output goes to `./output/`. If `/tmp` is a small tmpfs on your machi
 git clone https://github.com/projectbluefin/dakota-iso
 cd dakota-iso
 
-# Full build — live env container + ISO assembly (single-variant, for local testing)
+# Full build — live env container + ISO assembly
 just iso-sd-boot dakota
-
-# Build the NVIDIA variant (boots live with NVIDIA drivers)
-just iso-sd-boot dakota-nvidia
 
 # Override output directory (if ./output/ is on a small filesystem)
 just output_dir=/var/data/iso-output iso-sd-boot dakota
@@ -64,19 +66,7 @@ just output_dir=/var/data/iso-output iso-sd-boot dakota
 
 The build takes **20–40 minutes** depending on your internet connection — the Flatpak install step downloads ~2 GB from Flathub.
 
-Output: `output/<target>-live.iso` (~4.5 GB)
-
-> **CI builds** a unified ISO containing both NVIDIA (live boot) and non-NVIDIA (offline
-> install) variants. To replicate the full CI pipeline locally, run the three scripts
-> directly:
-> ```bash
-> sudo bash scripts/build-live-squashfs.sh localhost/dakota-nvidia-live:latest \
->   output/dakota-nvidia.rootfs.sfs output/dakota-nvidia-boot.tar
-> sudo bash scripts/build-offline-store.sh output/store.squashfs.img \
->   ghcr.io/projectbluefin/dakota-nvidia:latest ghcr.io/projectbluefin/dakota:latest
-> sudo bash live/src/build-iso.sh --store output/store.squashfs.img \
->   output/dakota-nvidia-boot.tar output/dakota-nvidia.rootfs.sfs output/dakota-live.iso
-> ```
+Output: `output/dakota-live.iso` (~4.3 GB)
 
 ### Build stages
 
@@ -85,9 +75,9 @@ just container dakota          # Build the live environment container
 just iso-sd-boot dakota        # Full end-to-end build (runs container + assembles ISO)
 ```
 
-## Adding a new variant
+## Adding a custom build
 
-Each variant is a directory containing a single file — `payload_ref` — with the OCI image reference:
+The justfile accepts any variant directory with a `payload_ref` file:
 
 ```bash
 mkdir my-variant
@@ -95,7 +85,9 @@ echo 'ghcr.io/projectbluefin/my-variant:latest' > my-variant/payload_ref
 just iso-sd-boot my-variant
 ```
 
-The Containerfile (`live/Containerfile`) accepts a `TARGET` build-arg (defaulting to `dakota-nvidia`). The justfile reads `<target>/payload_ref` but passes the target name directly as `TARGET`. The installer configs inside the ISO are patched at build time to reference the correct image.
+The `live/Containerfile` accepts a `TARGET` build-arg (defaulting to `dakota-nvidia`). The
+justfile reads `<target>/payload_ref` and passes the target name as `TARGET`. Installer
+configs are patched at build time to reference the correct image.
 
 ## Testing
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,12 +6,11 @@ How to build Dakota live ISOs locally and the key variables that control the bui
 
 ```bash
 just iso-sd-boot dakota               # full build, stable installer
-just iso-sd-boot dakota-nvidia        # NVIDIA variant
 just debug=1 installer_channel=dev iso-sd-boot dakota  # debug + dev installer
 just build-bg dakota                  # background build (survives terminal close)
 ```
 
-Output: `output/<target>-live.iso` (~4.5 GB, ~20–40 min depending on network)
+Output: `output/dakota-live.iso` (~4.3 GB, ~20–40 min depending on network)
 
 ## Key variables
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -65,8 +65,8 @@ If both checks fail after 5 minutes, the job fails with `tail -50 /tmp/serial.lo
 ### R2 upload
 
 ISOs are uploaded to the `testing` bucket as:
-- `<target>-live-YYYYMMDD-<sha>.iso` — permanent dated record
-- `<target>-live-latest.iso` — always points to the last successful build
+- `dakota-live-YYYYMMDD-<sha>.iso` — permanent dated record
+- `dakota-live-latest.iso` — always points to the last successful build
 - Matching `-CHECKSUM` files for both
 
 ⚠️ Direct uploads from the local host hang (routing issue). Always use R2→R2

--- a/docs/r2-promotion.md
+++ b/docs/r2-promotion.md
@@ -16,13 +16,16 @@ ISOs are permanent — no expiry. Full history from 2026-04-10.
 
 ## rclone config (`~/.config/rclone/rclone.conf`)
 
+> Credentials are not stored in this repo. Request them from a project maintainer
+> or retrieve them from the shared password manager.
+
 ```ini
 [R2]
 type = s3
 provider = Cloudflare
 region = auto
-access_key_id = abfd2b00ed95ee9b17b7c35a68b0f959
-secret_access_key = 8ab5b927c2bd2508cf3518fafaa458ba3176754f317291087dc3ab920d86490a
+access_key_id = <your-r2-access-key-id>
+secret_access_key = <your-r2-secret-access-key>
 endpoint = https://2a4147f637f7d9e6a67ca185357d3b0a.r2.cloudflarestorage.com
 acl = private
 no_check_bucket = true

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -1,45 +1,46 @@
 # Variants
 
-How Dakota ISO variants work and how to add new ones.
+How the Dakota ISO build target works.
 
-## Current variants
+## Current build
 
-| Variant | `payload_ref` | Role in unified ISO |
-|---|---|---|
-| `dakota` | `ghcr.io/projectbluefin/dakota:latest` | offline install (in `store.squashfs.img`) |
-| `dakota-nvidia` | `ghcr.io/projectbluefin/dakota-nvidia:latest` | live boot environment |
+There is one unified ISO: `dakota-live.iso`.
 
-CI produces **one unified ISO** (`dakota-live.iso`). The NVIDIA variant boots live; both
-variants are available for installation via the embedded offline store.
+| Build target | `payload_ref` | Live boot | Offline install |
+|---|---|---|---|
+| `dakota` | `ghcr.io/projectbluefin/dakota-nvidia:stable` | NVIDIA live env | NVIDIA VFS store (auto-rebases to non-NVIDIA on first upgrade) |
 
-## How variants work
+CI and local builds both use `just iso-sd-boot dakota`. There is no separate `dakota-nvidia`
+build target — the `dakota/live_target` file points to `dakota-nvidia` to select the right
+container image.
 
-Each variant is a directory containing a single file — `payload_ref` — with the OCI
-image reference.
+## How the build target works
+
+The `dakota/` directory contains two files:
 
 ```
 dakota/
-  payload_ref    ← ghcr.io/projectbluefin/dakota:latest
-dakota-nvidia/
-  payload_ref    ← ghcr.io/projectbluefin/dakota-nvidia:latest
+  payload_ref    ← ghcr.io/projectbluefin/dakota-nvidia:stable
+  live_target    ← dakota-nvidia
 ```
 
-The justfile reads `<target>/payload_ref` and uses it for squashfs assembly. The live
-container is built from `live/Containerfile` with `--build-arg TARGET=<target>`:
+The justfile reads `<target>/payload_ref` for the OCI image to embed and `<target>/live_target`
+for the container build arg. The live container is built from `live/Containerfile` with
+`--build-arg TARGET=<live_target>`:
 
 ```makefile
 container target:
     podman build \
-        --build-arg TARGET={{target}} \
+        --build-arg TARGET={{live_target}} \
         -t {{target}}-installer -f ./live/Containerfile ./live
 ```
 
 The installer configs inside the ISO (`images.json`, `recipe.json`) are patched at
 build time to reference the correct image via `configure-live.sh`.
 
-## Adding a new variant
+## Adding a custom build target
 
-For local testing, create a `<variant>/payload_ref` and run `just iso-sd-boot`:
+For local testing, create a directory with `payload_ref` and optionally `live_target`:
 
 ```bash
 mkdir my-variant
@@ -48,32 +49,6 @@ just iso-sd-boot my-variant
 ```
 
 Output: `output/my-variant-live.iso`
-
-To include the new variant in CI's unified ISO, add it to the `build-offline-store.sh`
-invocation in `build-iso.yml` so the offline store carries the new image:
-
-```yaml
-- name: Build offline image store squashfs
-  run: |
-    sudo bash scripts/build-offline-store.sh \
-      /var/iso-build/store.squashfs.img \
-      ghcr.io/projectbluefin/dakota-nvidia:latest \
-      ghcr.io/projectbluefin/dakota:latest \
-      ghcr.io/projectbluefin/my-variant:latest   # ← add here
-```
-
-And if the new variant should boot live (not just be installable), update the
-live container build step to use `--build-arg TARGET=my-variant`.
-
-## Installer branding per variant
-
-The installer branding (`distro_name`, `distro_logo`, tour slides) is defined in
-`live/src/etc/bootc-installer/recipe.json`. This is shared across all variants.
-
-If a variant needs different branding:
-1. Create `<variant>/recipe.json` with the custom content
-2. Update `configure-live.sh` to copy `<variant>/recipe.json` if it exists,
-   falling back to `live/src/etc/bootc-installer/recipe.json`
 
 ## `images.json` — catalog lock
 


### PR DESCRIPTION
Real-looking API key values were committed in plain text in docs/r2-promotion.md. Replace with placeholder strings and add a note directing contributors to obtain credentials from a project maintainer or the shared password manager.

Credentials have been rotated separately.