### PR TITLE
fix: stop baking VFS storage.conf into the payload image

### DIFF
--- a/scripts/build-live-squashfs.sh
+++ b/scripts/build-live-squashfs.sh
@@ -159,9 +159,10 @@ if [[ -n "${OCI_IMAGE}" ]]; then
         printf '[install]\nroot-mount-spec = "LABEL=root"\n' > "${WORK}/bootc-root-mount.toml"
         buildah copy "${SQUASH_CTR}" "${WORK}/bootc-root-mount.toml" /tmp/.bootc-root-mount.toml
         buildah run  "${SQUASH_CTR}" -- sh -c 'cp /tmp/.bootc-root-mount.toml /usr/lib/bootc/install/00-defaults.toml && rm /tmp/.bootc-root-mount.toml'
-        printf '[storage]\ndriver = "vfs"\nrunroot = "/run/containers/storage"\ngraphroot = "/var/lib/containers/storage"\n' > "${WORK}/vfs-storage.conf"
-        buildah run  "${SQUASH_CTR}" -- mkdir -p /etc/containers
-        buildah copy "${SQUASH_CTR}" "${WORK}/vfs-storage.conf" /etc/containers/storage.conf
+        # The payload ships verbatim to installed systems — never bake a
+        # storage.conf into it (installed podman would inherit VFS storage).
+        # VFS config for reading the embedded store lives in the live env
+        # (configure-live.sh) and the import step below (CONTAINERS_STORAGE_CONF).
         buildah commit --squash "${SQUASH_CTR}" "oci-archive:${OCI_ARCHIVE}:${OCI_IMAGE}"
         buildah rm "${SQUASH_CTR}"
 

--- a/scripts/iso-sd-boot.sh
+++ b/scripts/iso-sd-boot.sh
@@ -91,9 +91,10 @@ _ns "buildah copy '${INJECT_CTR}' '${OUTPUT_DIR}/.bootc-root-mount.toml' /tmp/.b
 _ns "buildah run '${INJECT_CTR}' -- sh -c 'mkdir -p /usr/lib/bootc/install && cp /tmp/.bootc-root-mount.toml /usr/lib/bootc/install/00-defaults.toml && rm /tmp/.bootc-root-mount.toml'"
 
 if [[ "${COMPOSEFS_BACKEND}" == "true" ]]; then
-    printf '[storage]\ndriver = "vfs"\nrunroot = "/run/containers/storage"\ngraphroot = "/var/lib/containers/storage"\n' > "${OUTPUT_DIR}/.vfs-storage.conf"
-    _ns "buildah run '${INJECT_CTR}' -- mkdir -p /etc/containers"
-    _ns "buildah copy '${INJECT_CTR}' '${OUTPUT_DIR}/.vfs-storage.conf' /etc/containers/storage.conf"
+    # The payload ships verbatim to installed systems — never bake a
+    # storage.conf into it (installed podman would inherit VFS storage).
+    # VFS config for reading the embedded store lives in the live env
+    # (configure-live.sh) and the embed step below (CONTAINERS_STORAGE_CONF).
     echo "=== Squashing ${PAYLOAD_IMAGE} to single layer (avoids VFS explosion) ==="
     _ns "buildah commit --squash '${INJECT_CTR}' 'oci-archive:${PAYLOAD_OCI}:${PAYLOAD_IMAGE}'"
     _ns "buildah rm '${INJECT_CTR}'"

--- a/tests/test_live_build_invariants.py
+++ b/tests/test_live_build_invariants.py
@@ -42,6 +42,7 @@ TEST_PLAIN_WORKFLOW = REPO / ".github" / "workflows" / "test-plain-install.yml"
 LIVE_LUKS_UNLOCK = REPO / "live" / "src" / "luks-unlock.py"
 DAKOTA_LUKS_UNLOCK = REPO / "dakota" / "src" / "luks-unlock.py"
 BUILD_LIVE_SQUASHFS = REPO / "scripts" / "build-live-squashfs.sh"
+ISO_SD_BOOT = REPO / "scripts" / "iso-sd-boot.sh"
 README = REPO / "README.md"
 
 # Variant directories that must be fully configured.
@@ -900,4 +901,44 @@ class TestBuildLiveSquashfs(unittest.TestCase):
                     f"Line in justfile uses raw 'socat' with UNIX-CONNECT: {line!r}. "
                     "Must use '$SOCAT_PREFIX socat' to support root-owned sockets "
                     "when QEMU runs with sudo."
+                )
+
+
+class TestPayloadPristine(unittest.TestCase):
+    """The embedded payload image must ship the same content the registry serves.
+
+    The payload OCI image embedded in the ISO is what bootc deploys — every
+    file baked into it at ISO build time ends up on the installed system.
+    Injecting a `driver = "vfs"` /etc/containers/storage.conf into the payload
+    (once done so podman could read the embedded VFS store) made every
+    installed system run podman with VFS storage: no overlay, massive disk
+    usage, and broken update-staging pulls. The live environment gets its own
+    storage.conf from configure-live.sh, the store-embed step passes one via
+    CONTAINERS_STORAGE_CONF, and fisherman bind-mounts one into the install
+    container when needed — the payload itself never needs it.
+
+    Only the bootc install config (/usr/lib/bootc/install/00-defaults.toml)
+    may be injected into the payload.
+    """
+
+    PAYLOAD_SCRIPTS = {
+        "scripts/iso-sd-boot.sh": ISO_SD_BOOT,
+        "scripts/build-live-squashfs.sh": BUILD_LIVE_SQUASHFS,
+    }
+
+    def test_no_storage_conf_injected_into_payload(self):
+        """No build script may buildah-copy a storage.conf into the payload."""
+        pattern = re.compile(
+            r"buildah copy.*(?:/etc/containers/storage\.conf|storage\.conf.*/etc/containers)"
+        )
+        for name, path in self.PAYLOAD_SCRIPTS.items():
+            for line in path.read_text().splitlines():
+                self.assertIsNone(
+                    pattern.search(line),
+                    f"{name} injects a storage.conf into the payload image: "
+                    f"{line.strip()!r}. The installed system inherits payload "
+                    "content verbatim — it would run podman with VFS storage. "
+                    "Configure storage for the live env (configure-live.sh), "
+                    "the embed step (CONTAINERS_STORAGE_CONF), or the install "
+                    "container (fisherman bind-mount) instead.",
                 )


### PR DESCRIPTION
## Summary

The composefs embed path injects `driver = "vfs"` into the payload image's `/etc/containers/storage.conf` before squashing (both `scripts/iso-sd-boot.sh` and `scripts/build-live-squashfs.sh`). The payload ships **verbatim** to installed systems, so every ISO-installed machine inherits VFS podman storage: no overlay driver, dramatically higher disk usage per image, and slow/duplicating pulls for any day-2 container workload or update tooling that goes through podman. It also silently clobbers any storage.conf the payload image legitimately ships.

Nothing in the install flow reads the baked file — it appears to be vestigial:
- the **live environment's** VFS config comes from `configure-live.sh`
- the **store-embed step** passes its own config via `CONTAINERS_STORAGE_CONF`
- **fisherman** installs via `--source-imgref oci:` in the composefs flow and bind-mounts a storage.conf into the install container when it needs one

## Changes

- Remove the storage.conf injection from both build paths. The intended `/usr/lib/bootc/install/00-defaults.toml` injection is unchanged.
- Add `TestPayloadPristine` to the invariants suite: forbids buildah-copying any storage.conf into the payload, with a comment explaining why.

## Verification

On a downstream Debian-bootc variant built from this repo (composefs, systemd-boot): full ISO rebuild with the fix, embedded payload verified clean via `podman image mount` in the live env, offline fisherman install from the embedded store (~2 min), installed system boots `running`/0 failed units with **`podman info` reporting the overlay driver**. Invariants suite passes (44/44 on this branch).

We've been running this in production ISO builds since. Happy to adjust if any variant's flow does consume the baked file — we couldn't find one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the embedded OCI payload as-is during live image creation, avoiding unintended storage configuration changes.
  * Improved consistency of container storage behavior during boot and import steps.

* **Tests**
  * Added coverage to ensure the payload build process does not inject container storage configuration files.
  * Added checks for both live image build paths to catch regressions early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->